### PR TITLE
chore(deps): fix package-lock.json bluebird@3.5.5 mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "bluebird": "3.5.5",
+        "bluebird": "3.7.2",
         "check-more-types": "2.24.0",
         "debug": "4.3.4",
         "execa": "1.0.0",
@@ -1659,12 +1659,6 @@
         "sensitive-files": "bin/ban.js"
       }
     },
-    "node_modules/ban-sensitive-files/node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "dev": true
-    },
     "node_modules/ban-sensitive-files/node_modules/colors": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
@@ -1902,9 +1896,10 @@
       "dev": true
     },
     "node_modules/bluebird": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "license": "MIT"
     },
     "node_modules/bottleneck": {
       "version": "2.19.5",
@@ -22182,12 +22177,6 @@
         "update-notifier": "5.1.0"
       },
       "dependencies": {
-        "bluebird": {
-          "version": "3.7.2",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-          "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-          "dev": true
-        },
         "colors": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
@@ -28624,9 +28613,9 @@
       }
     },
     "normalize-url": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-5.3.1.tgz",
-      "integrity": "sha512-K1c7+vaAP+Yh5bOGmA10PGPpp+6h7WZrl7GwqKhUflBc9flU9pzG27DDeB9+iuhZkE3BJZOcgN1P/2sS5pqrWw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-5.3.0.tgz",
+      "integrity": "sha512-9/nOVLYYe/dO/eJeQUNaGUF4m4Z5E7cb9oNTKabH+bNf19mqj60txTcveQxL0GlcWLXCxkOu2/LwL8oW0idIDA==",
       "dev": true
     },
     "npm": {


### PR DESCRIPTION
- closes https://github.com/cypress-io/commit-info/issues/161

## Situation

The npm [package-lock.json](https://github.com/cypress-io/commit-info/blob/master/package-lock.json) lock file is out of sync with the [package.json](https://github.com/cypress-io/commit-info/blob/master/package.json).

`npm ci` results in the error message

> npm error Invalid: lock file's bluebird@3.5.5 does not satisfy bluebird@3.7.2

## Change

Using Ubuntu `24.04.3` LTS, Node.js `22.18.0` LTS, regenerate [package-lock.json](https://github.com/cypress-io/commit-info/blob/master/package-lock.json) with:

```shell
npm install
```

## Verification

```shell
git clean -xfd
npm ci
```
