### PR TITLE
ci: update workflow main.yml to node20 / Node.js 22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,14 +1,18 @@
 name: Test and Release (if master)
-on: push
+on:
+  push:
+  pull_request:
+    branches:
+      - 'master'
 jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
       - run: npm ci
       - run: npm test
       # - if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
## Situation

The GitHub Actions workflow [.github/workflows/main.yml](https://github.com/cypress-io/commit-info/blob/master/.github/workflows/main.yml) is outdated, relying on Node.js 16 that entered [end-of-life status](https://nodejs.org/en/blog/announcements/nodejs16-eol/) on Sep 11, 2023.

- [actions/checkout@v3](https://github.com/actions/checkout/tree/v3) uses `node16`
- [actions/setup-node@v3](https://github.com/actions/setup-node/tree/v3) uses `node16`
- `node-version: 16` as a parameter installs Node.js `16.x`

The workflow triggers on `push` and does not use `pull_request`. This may miss issues if there is a delay between pushing to a branch and creating a PR, and there are environmental changes like a new Node.js release in the interim.

The CI result should also be visible in any PR. This requires setting the `pull_request` event trigger.

## Change

- Add an event trigger for PR to the default `master` branch.

Update to:
- [actions/checkout@v4](https://github.com/actions/checkout/tree/v4) for current `node20` usage
- [actions/setup-node@v4](https://github.com/actions/setup-node/tree/v4) for current `node20` usage
- `node-version: 22` using the [Node.js Active LTS version](https://github.com/nodejs/release#release-schedule)

The `semantic-release` step remains commented out at this stage, pending follow-on PRs.