### PR TITLE
chore(deps): remove outdated linting modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,16 +21,12 @@
         "chdir-promise": "0.6.2",
         "dependency-check": "4.1.0",
         "deps-ok": "1.4.1",
-        "dont-crack": "1.2.1",
         "git-issues": "1.3.1",
-        "github-post-release": "1.13.1",
         "license-checker": "25.0.1",
         "mocha": "6.2.1",
         "mocked-env": "1.3.1",
-        "pre-git": "3.17.1",
         "prettier-standard": "8.0.1",
         "semantic-release": "17.2.3",
-        "simple-commit-message": "4.1.3",
         "snap-shot-it": "7.9.3",
         "standard": "13.1.0",
         "stub-spawn-once": "2.3.0"
@@ -1124,25 +1120,6 @@
       "integrity": "sha512-vbAsWMVidKHi9Ji8wcpk4ftJBNaascKCxLiV3STxWwPVXkj+oaOUA81RN0lvDhEm0ynUl6C7UUhKGiruWIp7ZQ==",
       "dev": true
     },
-    "node_modules/agent-base": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
-      "dev": true,
-      "dependencies": {
-        "extend": "~3.0.0",
-        "semver": "~5.0.1"
-      }
-    },
-    "node_modules/agent-base/node_modules/semver": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-      "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -1191,15 +1168,6 @@
       "resolved": "https://registry.npmjs.org/always-error/-/always-error-1.0.0.tgz",
       "integrity": "sha1-lchAQs+obzjIbKbCzELAoBA0QbI=",
       "dev": true
-    },
-    "node_modules/am-i-a-dependency": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/am-i-a-dependency/-/am-i-a-dependency-1.1.2.tgz",
-      "integrity": "sha1-+dNCIwTW9kL4IeTEB1ZQNfYWfx8=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/ansi-align": {
       "version": "3.0.1",
@@ -1267,15 +1235,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/ansi-escapes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ansi-parser": {
@@ -1368,24 +1327,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/aproba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      }
-    },
     "node_modules/arg": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
@@ -1454,27 +1395,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "dependencies": {
-        "array-uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -1503,25 +1423,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/assign": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/assign/-/assign-0.1.7.tgz",
-      "integrity": "sha1-5jv+Ooh7hjCRPCdmPkzJv/Hd0l8=",
-      "dev": true,
-      "dependencies": {
-        "fusing": "0.4.x"
-      }
-    },
-    "node_modules/assign/node_modules/fusing": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/fusing/-/fusing-0.4.0.tgz",
-      "integrity": "sha1-yZBo9Uyj4R3AEYkCFSq/Nnq6Sk0=",
-      "dev": true,
-      "dependencies": {
-        "emits": "1.0.x",
-        "predefine": "0.1.x"
       }
     },
     "node_modules/astral-regex": {
@@ -1615,18 +1516,6 @@
       "dependencies": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
-      }
-    },
-    "node_modules/back": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/back/-/back-1.0.2.tgz",
-      "integrity": "sha1-qT9ebOaXKZhNWQGiuxbjsBpNY2k=",
-      "dev": true,
-      "dependencies": {
-        "xtend": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4.x || 0.12.x || 0.10.x || 0.8.x"
       }
     },
     "node_modules/balanced-match": {
@@ -2279,15 +2168,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/capture-stack-trace": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/cardinal": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
@@ -2357,12 +2237,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/chownr": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-0.0.2.tgz",
-      "integrity": "sha1-L5rr90b5CAjOAGB7crpztBYExIU=",
-      "dev": true
     },
     "node_modules/ci-info": {
       "version": "2.0.0",
@@ -2436,27 +2310,6 @@
       "dependencies": {
         "deffy": "2.0.0",
         "typpy": "2.0.0"
-      }
-    },
-    "node_modules/cli-boxes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cli-cursor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true,
-      "dependencies": {
-        "restore-cursor": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/cli-table": {
@@ -2570,61 +2423,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/color": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/color/-/color-0.8.0.tgz",
-      "integrity": "sha1-iQwHw/1OZJU3Y4kRz2keVFi2/KU=",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^0.5.0",
-        "color-string": "^0.3.0"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
-      "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=",
-      "dev": true
-    },
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
-    },
-    "node_modules/color-string": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-      "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-      "dev": true,
-      "dependencies": {
-        "color-name": "^1.0.0"
-      }
-    },
-    "node_modules/colornames": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz",
-      "integrity": "sha1-2BH9bIT1kClJmorEQ2ICk1uSvjE=",
-      "dev": true
-    },
-    "node_modules/colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "node_modules/colorspace": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.0.1.tgz",
-      "integrity": "sha1-yZx5btMRKLmHalLh7l7gOkpxl0k=",
-      "dev": true,
-      "dependencies": {
-        "color": "0.8.x",
-        "text-hex": "0.0.x"
-      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.6",
@@ -2636,31 +2439,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/commander": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true,
-      "dependencies": {
-        "graceful-readlink": ">= 1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6.x"
-      }
-    },
-    "node_modules/commit-closes": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commit-closes/-/commit-closes-1.0.1.tgz",
-      "integrity": "sha1-96rVyHy/0ZRTAgwZI3fBXdGsba4=",
-      "dev": true,
-      "dependencies": {
-        "check-more-types": "2.24.0",
-        "lazy-ass": "1.6.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/common-tags": {
@@ -2768,13 +2546,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
@@ -2845,60 +2616,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/conventional-commit-message": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-commit-message/-/conventional-commit-message-1.1.0.tgz",
-      "integrity": "sha1-7OjGYaFo6YNpLh1aFIday1lRD2o=",
-      "dev": true,
-      "dependencies": {
-        "check-more-types": "2.3.0",
-        "cz-conventional-changelog": "1.1.5",
-        "lazy-ass": "1.3.0",
-        "word-wrap": "1.1.0"
-      }
-    },
-    "node_modules/conventional-commit-message/node_modules/check-more-types": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.3.0.tgz",
-      "integrity": "sha1-uDl8adySo+ZF8YkywEWwnHRBnsQ=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/conventional-commit-message/node_modules/cz-conventional-changelog": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-1.1.5.tgz",
-      "integrity": "sha1-Ck0VUMTi+2o67Y9s2FjCF2DhGbg=",
-      "dev": true,
-      "dependencies": {
-        "word-wrap": "^1.0.3"
-      }
-    },
-    "node_modules/conventional-commit-message/node_modules/lazy-ass": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.3.0.tgz",
-      "integrity": "sha1-fQ0U7vPslwLG8wxg6oHxqNP5APs=",
-      "dev": true,
-      "engines": {
-        "node": "> 0.8"
-      }
-    },
-    "node_modules/conventional-commit-message/node_modules/word-wrap": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.1.0.tgz",
-      "integrity": "sha1-NWFT1h0QYQ1gB4XF1wEojgrnZKY=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/conventional-commit-types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-2.2.0.tgz",
-      "integrity": "sha1-XblXOdbCEqy+e29lahG5QLqmiUY=",
-      "dev": true
     },
     "node_modules/conventional-commits-filter": {
       "version": "2.0.7",
@@ -2987,15 +2704,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/couch-login": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/couch-login/-/couch-login-0.1.20.tgz",
-      "integrity": "sha1-AHxw74AInbrm9Z7u7DdIB5mzlZU=",
-      "dev": true,
-      "dependencies": {
-        "request": "2 >=2.25.0"
-      }
-    },
     "node_modules/couleurs": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/couleurs/-/couleurs-5.2.1.tgz",
@@ -3013,18 +2721,6 @@
       "integrity": "sha1-re87rMEv9Hr/kg+rA6j/MnnXN9Y=",
       "dev": true
     },
-    "node_modules/create-error-class": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "dev": true,
-      "dependencies": {
-        "capture-stack-trace": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -3036,15 +2732,6 @@
         "which": "^1.2.9"
       }
     },
-    "node_modules/crypto-random-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/custom-return": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/custom-return/-/custom-return-1.0.10.tgz",
@@ -3052,19 +2739,6 @@
       "dev": true,
       "dependencies": {
         "noop6": "^1.0.0"
-      }
-    },
-    "node_modules/cz-conventional-changelog": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-2.1.0.tgz",
-      "integrity": "sha1-L0vHOQ4yROTfKT5ro1Hkx0Cnx2Q=",
-      "dev": true,
-      "dependencies": {
-        "conventional-commit-types": "^2.0.0",
-        "lodash.map": "^4.5.1",
-        "longest": "^1.0.1",
-        "right-pad": "^1.0.1",
-        "word-wrap": "^1.0.3"
       }
     },
     "node_modules/d3-helpers": {
@@ -3291,24 +2965,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true,
-      "dependencies": {
-        "globby": "^5.0.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "rimraf": "^2.2.8"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -3317,13 +2973,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true,
-      "optional": true
     },
     "node_modules/dependency-check": {
       "version": "4.1.0",
@@ -3499,17 +3148,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/diagnostics": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.0.1.tgz",
-      "integrity": "sha1-rM2wgMgrsl0N1zQwqeaof7tDFUE=",
-      "dev": true,
-      "dependencies": {
-        "colorspace": "1.0.x",
-        "enabled": "1.0.x",
-        "kuler": "0.0.x"
-      }
-    },
     "node_modules/diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -3626,481 +3264,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/dont-break": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/dont-break/-/dont-break-1.5.0.tgz",
-      "integrity": "sha1-nzsgBXme5cPlmjK689rPJtNG6Bs=",
-      "dev": true,
-      "dependencies": {
-        "chdir-promise": "0.4.0",
-        "check-more-types": "2.24.0",
-        "commander": "2.9.0",
-        "debug": "2.6.8",
-        "fs-extra": "^3.0.1",
-        "ggit": "1.15.1",
-        "hr": "0.1.3",
-        "lazy-ass": "1.6.0",
-        "lodash": "4.17.4",
-        "npm-registry": "0.1.13",
-        "npm-utils": "1.12.0",
-        "os-tmpdir": "1.0.2",
-        "q": "2.0.3",
-        "quote": "0.4.0",
-        "rimraf": "2.6.1",
-        "strip-json-comments": "2.0.1",
-        "top-dependents": "1.0.0",
-        "update-notifier": "2.1.0"
-      },
-      "bin": {
-        "dont-break": "bin/dont-break"
-      },
-      "engines": {
-        "node": ">= 0.12.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/dont-break/node_modules/ansi-align": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^2.0.0"
-      }
-    },
-    "node_modules/dont-break/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/dont-break/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/dont-break/node_modules/bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
-      "dev": true
-    },
-    "node_modules/dont-break/node_modules/boxen": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
-      "dev": true,
-      "dependencies": {
-        "ansi-align": "^2.0.0",
-        "camelcase": "^4.0.0",
-        "chalk": "^2.0.1",
-        "cli-boxes": "^1.0.0",
-        "string-width": "^2.0.0",
-        "term-size": "^1.2.0",
-        "widest-line": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/dont-break/node_modules/boxen/node_modules/chalk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/dont-break/node_modules/camelcase": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/dont-break/node_modules/chdir-promise": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/chdir-promise/-/chdir-promise-0.4.0.tgz",
-      "integrity": "sha1-RtxgLtGTGXRwFA8VJFmkOCz3mXQ=",
-      "dev": true,
-      "dependencies": {
-        "check-more-types": "2.23.0",
-        "debug": "^2.3.3",
-        "lazy-ass": "1.5.0",
-        "q": "1.1.2",
-        "spots": "0.4.0"
-      }
-    },
-    "node_modules/dont-break/node_modules/chdir-promise/node_modules/check-more-types": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.23.0.tgz",
-      "integrity": "sha1-YiYmTTCxCVqhwKW4dO291dLQpm8=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/dont-break/node_modules/chdir-promise/node_modules/lazy-ass": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.5.0.tgz",
-      "integrity": "sha1-yhW+JDx8R1uFZc2/oPnC83TyoB0=",
-      "dev": true,
-      "engines": {
-        "node": "> 0.8"
-      }
-    },
-    "node_modules/dont-break/node_modules/chdir-promise/node_modules/q": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
-      "integrity": "sha1-Y1fikSBnAdmfGXq4TlforRlvKok=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
-      }
-    },
-    "node_modules/dont-break/node_modules/color-convert": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
-      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.1"
-      }
-    },
-    "node_modules/dont-break/node_modules/color-name": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
-      "dev": true
-    },
-    "node_modules/dont-break/node_modules/configstore": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
-      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
-      "dev": true,
-      "dependencies": {
-        "dot-prop": "^4.1.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "unique-string": "^1.0.0",
-        "write-file-atomic": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/dont-break/node_modules/debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/dont-break/node_modules/dot-prop": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-      "dev": true,
-      "dependencies": {
-        "is-obj": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/dont-break/node_modules/ggit": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/ggit/-/ggit-1.15.1.tgz",
-      "integrity": "sha1-gNVS6OFxLJgF/luhzxGaTn472Zg=",
-      "dev": true,
-      "dependencies": {
-        "bluebird": "3.5.0",
-        "chdir-promise": "0.4.0",
-        "check-more-types": "2.24.0",
-        "cli-table": "0.3.1",
-        "colors": "1.1.2",
-        "commander": "2.9.0",
-        "d3-helpers": "0.3.0",
-        "debug": "2.6.3",
-        "glob": "7.1.1",
-        "lazy-ass": "1.6.0",
-        "lodash": "3.10.1",
-        "moment": "2.18.1",
-        "optimist": "0.6.1",
-        "q": "2.0.3",
-        "quote": "0.4.0",
-        "ramda": "0.9.1"
-      },
-      "bin": {
-        "ggit": "bin/ggit.js",
-        "ggit-last": "bin/ggit-last"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/dont-break/node_modules/ggit/node_modules/debug": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
-      "integrity": "sha1-D364wwll7AjHKsz6ATDIt5mEFB0=",
-      "dev": true,
-      "dependencies": {
-        "ms": "0.7.2"
-      }
-    },
-    "node_modules/dont-break/node_modules/ggit/node_modules/lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-      "dev": true
-    },
-    "node_modules/dont-break/node_modules/ggit/node_modules/ms": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-      "dev": true
-    },
-    "node_modules/dont-break/node_modules/got": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-      "dev": true,
-      "dependencies": {
-        "create-error-class": "^3.0.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "is-redirect": "^1.0.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "safe-buffer": "^5.0.1",
-        "timed-out": "^4.0.0",
-        "unzip-response": "^2.0.1",
-        "url-parse-lax": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/dont-break/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/dont-break/node_modules/latest-version": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
-      "dev": true,
-      "dependencies": {
-        "package-json": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/dont-break/node_modules/lazy-req": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-2.0.0.tgz",
-      "integrity": "sha1-yUUKNj7N2i5vDHATKtTzf48G8rQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/dont-break/node_modules/lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-      "dev": true
-    },
-    "node_modules/dont-break/node_modules/moment": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/dont-break/node_modules/package-json": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-      "dev": true,
-      "dependencies": {
-        "got": "^6.7.1",
-        "registry-auth-token": "^3.0.1",
-        "registry-url": "^3.0.3",
-        "semver": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/dont-break/node_modules/ramda": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.9.1.tgz",
-      "integrity": "sha1-zJFNw6gsYI0AMJAgN4fD9oJsHYc=",
-      "dev": true
-    },
-    "node_modules/dont-break/node_modules/string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/dont-break/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/dont-break/node_modules/supports-color": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/dont-break/node_modules/timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/dont-break/node_modules/unzip-response": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/dont-break/node_modules/update-notifier": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.1.0.tgz",
-      "integrity": "sha1-7AweU1NrdmR6JLd8uDlm2TFRI9k=",
-      "dev": true,
-      "dependencies": {
-        "boxen": "^1.0.0",
-        "chalk": "^1.0.0",
-        "configstore": "^3.0.0",
-        "is-npm": "^1.0.0",
-        "latest-version": "^3.0.0",
-        "lazy-req": "^2.0.0",
-        "semver-diff": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/dont-break/node_modules/widest-line": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
-      "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/dont-break/node_modules/write-file-atomic": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "node_modules/dont-break/node_modules/xdg-basedir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/dont-crack": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/dont-crack/-/dont-crack-1.2.1.tgz",
-      "integrity": "sha1-yheZXEsD1O5JC7Jn0VMsM3iwaIk=",
-      "dev": true,
-      "dependencies": {
-        "always-error": "^1.0.0",
-        "check-more-types": "2.24.0",
-        "debug": "2.6.8",
-        "dont-break": "1.5.0",
-        "lazy-ass": "1.6.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/dont-crack/node_modules/debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
     "node_modules/dot-prop": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
@@ -4147,26 +3310,11 @@
         "jsbn": "~0.1.0"
       }
     },
-    "node_modules/emits": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/emits/-/emits-1.0.2.tgz",
-      "integrity": "sha1-2yDsZmgyUHHDE0QeMM/ipp6nOFk=",
-      "dev": true
-    },
     "node_modules/emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
-    },
-    "node_modules/enabled": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
-      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
-      "dev": true,
-      "dependencies": {
-        "env-variable": "0.0.x"
-      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.1",
@@ -4330,12 +3478,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/env-variable": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.4.tgz",
-      "integrity": "sha512-+jpGxSWG4vr6gVxUHOc4p+ilPnql7NzZxOZBxNldsKGjCF+97df3CbuX7XMaDa5oAVkKQj4rKp38rYdC4VcpDg==",
-      "dev": true
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -5352,12 +4494,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
-      "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
-      "dev": true
-    },
     "node_modules/exclude-arr": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/exclude-arr/-/exclude-arr-1.0.9.tgz",
@@ -5417,25 +4553,10 @@
         "node": ">=6"
       }
     },
-    "node_modules/exit-hook": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
-    },
-    "node_modules/extendible": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/extendible/-/extendible-0.1.1.tgz",
-      "integrity": "sha1-4qN+2HEp+0+VM+io11BiMKU5yQU=",
       "dev": true
     },
     "node_modules/external-editor": {
@@ -5451,12 +4572,6 @@
       "engines": {
         "node": ">=0.12"
       }
-    },
-    "node_modules/extract-github": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/extract-github/-/extract-github-0.0.5.tgz",
-      "integrity": "sha1-9UJTbbjBm5g6O+yduW0u8qX/GoY=",
-      "dev": true
     },
     "node_modules/extsprintf": {
       "version": "1.3.0",
@@ -5511,19 +4626,6 @@
         "reusify": "^1.0.0"
       }
     },
-    "node_modules/figures": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true,
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/file-entry-cache": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
@@ -5552,12 +4654,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fillo/-/fillo-1.0.11.tgz",
       "integrity": "sha512-3YWc82rxHEJUCMbHXxYwnu6X4zmOKjqVLtU0NsTOaPFj1lF8YaqodE+efvEPyq7kL5W8kT91OfO6KU1HVwBDzQ==",
-      "dev": true
-    },
-    "node_modules/find-parent-dir": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
-      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
       "dev": true
     },
     "node_modules/find-root": {
@@ -5597,40 +4693,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/findup": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
-      "integrity": "sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=",
-      "dev": true,
-      "dependencies": {
-        "colors": "~0.6.0-1",
-        "commander": "~2.1.0"
-      },
-      "bin": {
-        "findup": "bin/findup.js"
-      },
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/findup/node_modules/colors": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "node_modules/findup/node_modules/commander": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
-      "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6.x"
       }
     },
     "node_modules/flat": {
@@ -5732,25 +4794,6 @@
       "deprecated": "This package is no longer actively maintained. Only security patches will be provided, if needed. Consider switching to fp-ts.",
       "dev": true
     },
-    "node_modules/follow-redirects": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
-      "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk=",
-      "dev": true,
-      "dependencies": {
-        "debug": "^2.2.0",
-        "stream-consume": "^0.1.0"
-      }
-    },
-    "node_modules/follow-redirects/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -5759,12 +4802,6 @@
       "dependencies": {
         "is-callable": "^1.1.3"
       }
-    },
-    "node_modules/foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
     },
     "node_modules/forever-agent": {
       "version": "0.6.1",
@@ -5809,17 +4846,6 @@
       "dependencies": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
-      "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^3.0.0",
-        "universalify": "^0.1.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -5876,32 +4902,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/fusing": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/fusing/-/fusing-0.2.3.tgz",
-      "integrity": "sha1-0O76+YXSuv3tRK+LGFMW9uQp4ds=",
-      "dev": true,
-      "dependencies": {
-        "predefine": "0.1.x"
-      }
-    },
-    "node_modules/gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -5934,15 +4934,6 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/get-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/get-symbol-description": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
@@ -5966,109 +4957,6 @@
       "dev": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
-      }
-    },
-    "node_modules/ggit": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/ggit/-/ggit-2.4.2.tgz",
-      "integrity": "sha512-4pltyhG4cjVT1Nqs9pq8Iykc/lTibc4LKRUAxszA9+OgwpfGhbsFgzhtyXwh5AbiWZrBa87nIHzyVGlJoT4nCw==",
-      "dev": true,
-      "dependencies": {
-        "always-error": "1.0.0",
-        "bluebird": "3.5.1",
-        "chdir-promise": "0.6.2",
-        "check-more-types": "2.24.0",
-        "cli-table": "0.3.1",
-        "colors": "1.1.2",
-        "commander": "2.12.2",
-        "d3-helpers": "0.3.0",
-        "debug": "3.1.0",
-        "find-up": "2.1.0",
-        "glob": "7.1.2",
-        "lazy-ass": "1.6.0",
-        "lodash": "4.17.4",
-        "moment": "2.19.3",
-        "moment-timezone": "0.5.14",
-        "optimist": "0.6.1",
-        "pluralize": "7.0.0",
-        "q": "2.0.3",
-        "quote": "0.4.0",
-        "ramda": "0.25.0",
-        "semver": "5.4.1"
-      },
-      "bin": {
-        "ggit": "bin/ggit.js"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/ggit/node_modules/bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-      "dev": true
-    },
-    "node_modules/ggit/node_modules/commander": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
-      "dev": true
-    },
-    "node_modules/ggit/node_modules/debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/ggit/node_modules/glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/ggit/node_modules/lodash": {
-      "version": "4.17.4",
-      "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-      "dev": true
-    },
-    "node_modules/ggit/node_modules/moment": {
-      "version": "2.19.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.3.tgz",
-      "integrity": "sha1-vbmdJw1tf9p4zA+6zoVeJ/59pp8=",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/ggit/node_modules/ramda": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
-      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==",
-      "dev": true
-    },
-    "node_modules/ggit/node_modules/semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/git-issues": {
@@ -6141,269 +5029,6 @@
       "dev": true,
       "dependencies": {
         "git-up": "^1.0.0"
-      }
-    },
-    "node_modules/github": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/github/-/github-9.2.0.tgz",
-      "integrity": "sha1-iohtxA3WNjZwfcr5nfPfJsWfFvw=",
-      "deprecated": "'github' has been renamed to '@octokit/rest' (https://git.io/vNB11)",
-      "dev": true,
-      "dependencies": {
-        "follow-redirects": "0.0.7",
-        "https-proxy-agent": "^1.0.0",
-        "mime": "^1.2.11",
-        "netrc": "^0.1.4"
-      }
-    },
-    "node_modules/github-post-release": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/github-post-release/-/github-post-release-1.13.1.tgz",
-      "integrity": "sha1-pJVqWfl4fs9DdpvWBzSsDLVXU6Q=",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "am-i-a-dependency": "1.1.2",
-        "bluebird": "3.5.0",
-        "check-more-types": "2.24.0",
-        "commit-closes": "1.0.1",
-        "common-tags": "1.4.0",
-        "debug": "3.0.0",
-        "github": "9.2.0",
-        "github-url-from-git": "1.5.0",
-        "lazy-ass": "1.6.0",
-        "new-public-commits": "1.3.1",
-        "parse-github-repo-url": "1.4.0",
-        "pluralize": "6.0.0",
-        "ramda": "0.24.1",
-        "simple-changelog": "1.1.3",
-        "simple-commit-message": "3.3.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/github-post-release/node_modules/bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
-      "dev": true
-    },
-    "node_modules/github-post-release/node_modules/chdir-promise": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/chdir-promise/-/chdir-promise-0.4.1.tgz",
-      "integrity": "sha1-GIi7M3GWmcn7chOMB1VlA8SRPoU=",
-      "dev": true,
-      "dependencies": {
-        "check-more-types": "2.24.0",
-        "debug": "2.6.8",
-        "lazy-ass": "1.6.0",
-        "q": "1.5.0",
-        "spots": "0.5.0"
-      }
-    },
-    "node_modules/github-post-release/node_modules/chdir-promise/node_modules/debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/github-post-release/node_modules/chdir-promise/node_modules/q": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
-      "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
-      }
-    },
-    "node_modules/github-post-release/node_modules/commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-      "dev": true
-    },
-    "node_modules/github-post-release/node_modules/debug": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.0.0.tgz",
-      "integrity": "sha512-XQkHxxqbsCb+zFurCHbotmJZl5jXsxvkRt952pT6Hpo7LmjWAJF12d9/kqBg5owjbLADbBDli1olravjSiSg8g==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/github-post-release/node_modules/ggit": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/ggit/-/ggit-1.23.1.tgz",
-      "integrity": "sha1-5RPC8iKmJJpG5NDfNUuGBLW67ts=",
-      "dev": true,
-      "dependencies": {
-        "always-error": "1.0.0",
-        "bluebird": "3.5.0",
-        "chdir-promise": "0.4.1",
-        "check-more-types": "2.24.0",
-        "cli-table": "0.3.1",
-        "colors": "1.1.2",
-        "commander": "2.11.0",
-        "d3-helpers": "0.3.0",
-        "debug": "2.6.8",
-        "find-up": "2.1.0",
-        "glob": "7.1.2",
-        "lazy-ass": "1.6.0",
-        "lodash": "3.10.1",
-        "moment": "2.18.1",
-        "optimist": "0.6.1",
-        "pluralize": "6.0.0",
-        "q": "2.0.3",
-        "quote": "0.4.0",
-        "ramda": "0.24.1",
-        "semver": "5.4.1"
-      },
-      "bin": {
-        "ggit": "bin/ggit.js",
-        "ggit-last": "bin/ggit-last"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/github-post-release/node_modules/ggit/node_modules/debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/github-post-release/node_modules/glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/github-post-release/node_modules/moment": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/github-post-release/node_modules/pluralize": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-6.0.0.tgz",
-      "integrity": "sha1-2bUa+tl9PVEHXMHdupsTLKzMt7o=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/github-post-release/node_modules/ramda": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
-      "integrity": "sha1-w7d1UZfzW43DUCIoJixMkd22uFc=",
-      "dev": true
-    },
-    "node_modules/github-post-release/node_modules/semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/github-post-release/node_modules/simple-commit-message": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/simple-commit-message/-/simple-commit-message-3.3.1.tgz",
-      "integrity": "sha512-TGODO8KgYQqd/Y/Ik1cdwUXp3mxvrWPBeB87xRzDnoru6dLsgaJkLxu9Db7+kjkbhvEMnnKbPgJb4h4iq1aHZw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "am-i-a-dependency": "1.0.0",
-        "check-more-types": "2.24.0",
-        "debug": "2.6.8",
-        "ggit": "1.23.1",
-        "hr": "0.1.3",
-        "inquirer": "0.12.0",
-        "inquirer-confirm": "0.2.2",
-        "largest-semantic-change": "1.0.0",
-        "lazy-ass": "1.6.0",
-        "semver": "5.4.1",
-        "word-wrap": "1.2.3"
-      },
-      "bin": {
-        "simple-commit-message": "bin/simple-wizard.js"
-      }
-    },
-    "node_modules/github-post-release/node_modules/simple-commit-message/node_modules/am-i-a-dependency": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/am-i-a-dependency/-/am-i-a-dependency-1.0.0.tgz",
-      "integrity": "sha1-fA4usSYEU1CFLibkT2eBs+04eRk=",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/github-post-release/node_modules/simple-commit-message/node_modules/debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/github-post-release/node_modules/spots": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/spots/-/spots-0.5.0.tgz",
-      "integrity": "sha1-t6oPGsOJpabVfCHpjaHVODlAX+E=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/github-url-from-git": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
-      "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA=",
-      "dev": true
-    },
-    "node_modules/githulk": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/githulk/-/githulk-0.0.7.tgz",
-      "integrity": "sha1-2Wyinw7EMRfFOOUh1mNWbqhLTv8=",
-      "dev": true,
-      "dependencies": {
-        "debug": "0.7.x",
-        "extract-github": "0.0.x",
-        "mana": "0.1.x"
-      }
-    },
-    "node_modules/githulk/node_modules/debug": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-      "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/glob": {
@@ -6483,23 +5108,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/globby": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true,
-      "dependencies": {
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -6575,12 +5183,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
     },
     "node_modules/growl": {
       "version": "1.10.5",
@@ -6778,13 +5380,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/has-yarn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
@@ -6817,18 +5412,6 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
-    },
-    "node_modules/hr": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/hr/-/hr-0.1.3.tgz",
-      "integrity": "sha1-2aow9ZKdq/0LZbo5WTij4YTbyv4=",
-      "dev": true,
-      "bin": {
-        "hr": "bin/hr"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
@@ -6875,26 +5458,6 @@
       "engines": {
         "node": ">=0.8",
         "npm": ">=1.3.7"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "2",
-        "debug": "2",
-        "extend": "3"
-      }
-    },
-    "node_modules/https-proxy-agent/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
       }
     },
     "node_modules/human-signals": {
@@ -6997,12 +5560,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
-      "dev": true
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -7029,111 +5586,6 @@
         "node": "*"
       }
     },
-    "node_modules/inquirer": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-      "dev": true,
-      "dependencies": {
-        "ansi-escapes": "^1.1.0",
-        "ansi-regex": "^2.0.0",
-        "chalk": "^1.0.0",
-        "cli-cursor": "^1.0.1",
-        "cli-width": "^2.0.0",
-        "figures": "^1.3.5",
-        "lodash": "^4.3.0",
-        "readline2": "^1.0.1",
-        "run-async": "^0.1.0",
-        "rx-lite": "^3.1.2",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.0",
-        "through": "^2.3.6"
-      }
-    },
-    "node_modules/inquirer-confirm": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/inquirer-confirm/-/inquirer-confirm-0.2.2.tgz",
-      "integrity": "sha1-b0BtA3v52eRV7w+VOSnzV/6aiEg=",
-      "dev": true,
-      "dependencies": {
-        "bluebird": "2.9.24",
-        "inquirer": "0.8.2"
-      }
-    },
-    "node_modules/inquirer-confirm/node_modules/ansi-regex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-      "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/inquirer-confirm/node_modules/bluebird": {
-      "version": "2.9.24",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.24.tgz",
-      "integrity": "sha1-FKLnXwVIMj3DWqRA2SAHyhVOlnw=",
-      "dev": true
-    },
-    "node_modules/inquirer-confirm/node_modules/cli-width": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
-      "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=",
-      "dev": true
-    },
-    "node_modules/inquirer-confirm/node_modules/inquirer": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.2.tgz",
-      "integrity": "sha1-QVhlSOHF2bP4HfcyUDS6rKtvWKs=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^1.1.1",
-        "chalk": "^1.0.0",
-        "cli-width": "^1.0.1",
-        "figures": "^1.3.5",
-        "lodash": "^3.3.1",
-        "readline2": "^0.1.1",
-        "rx": "^2.4.3",
-        "through": "^2.3.6"
-      }
-    },
-    "node_modules/inquirer-confirm/node_modules/mute-stream": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
-      "integrity": "sha1-qSGZYKbV1dBGWXruUSUsZlX3F34=",
-      "dev": true
-    },
-    "node_modules/inquirer-confirm/node_modules/readline2": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
-      "integrity": "sha1-mUQ7pug7gw7zBRv9fcJBqCco1Wg=",
-      "dev": true,
-      "dependencies": {
-        "mute-stream": "0.0.4",
-        "strip-ansi": "^2.0.1"
-      }
-    },
-    "node_modules/inquirer-confirm/node_modules/strip-ansi": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-      "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^1.0.0"
-      },
-      "bin": {
-        "strip-ansi": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/inquirer/node_modules/lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-      "dev": true
-    },
     "node_modules/internal-slot": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
@@ -7148,12 +5600,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/interpret": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
-      "dev": true
-    },
     "node_modules/into-stream": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-5.1.1.tgz",
@@ -7165,15 +5611,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/is/-/is-0.2.7.tgz",
-      "integrity": "sha1-OzSixI81mXLzUEKEkZOucmS2NWI=",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/is-array-buffer": {
@@ -7357,15 +5794,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-npm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -7390,54 +5818,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-object": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-0.1.2.tgz",
-      "integrity": "sha1-AO+8CIFsM8/ErIJR0TLhDcZQmNc=",
-      "dev": true
-    },
-    "node_modules/is-path-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-path-in-cwd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-      "dev": true,
-      "dependencies": {
-        "is-path-inside": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-path-inside": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
-      "dependencies": {
-        "path-is-inside": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
@@ -7451,21 +5831,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
-    },
-    "node_modules/is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -7504,15 +5869,6 @@
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
-    },
-    "node_modules/is-retry-allowed": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.2",
@@ -7783,15 +6139,6 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
-    "node_modules/jsonfile": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
-      "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
-      "dev": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -7861,46 +6208,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/kuler": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz",
-      "integrity": "sha1-tmu0a5NOVQ9Z2BiEjgq7pPf1VTw=",
-      "dev": true,
-      "dependencies": {
-        "colornames": "0.0.2"
-      }
-    },
-    "node_modules/largest-semantic-change": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/largest-semantic-change/-/largest-semantic-change-1.0.0.tgz",
-      "integrity": "sha1-JdxTi9qqi73DAnax6/kC1Ho0vw4=",
-      "dev": true,
-      "dependencies": {
-        "check-more-types": "2.23.0",
-        "lazy-ass": "1.5.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/largest-semantic-change/node_modules/check-more-types": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.23.0.tgz",
-      "integrity": "sha1-YiYmTTCxCVqhwKW4dO291dLQpm8=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/largest-semantic-change/node_modules/lazy-ass": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.5.0.tgz",
-      "integrity": "sha1-yhW+JDx8R1uFZc2/oPnC83TyoB0=",
-      "dev": true,
-      "engines": {
-        "node": "> 0.8"
       }
     },
     "node_modules/latest-version": {
@@ -8055,34 +6362,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/licenses": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/licenses/-/licenses-0.0.20.tgz",
-      "integrity": "sha1-8YpXsmp46vKKhz4qN4oz6B9Z0TY=",
-      "dev": true,
-      "dependencies": {
-        "async": "0.6.x",
-        "debug": "0.8.x",
-        "fusing": "0.2.x",
-        "githulk": "0.0.x",
-        "npm-registry": "0.1.x"
-      }
-    },
-    "node_modules/licenses/node_modules/async": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.6.2.tgz",
-      "integrity": "sha1-Qf0DijgSwKi8GELs8IumPrA5K+8=",
-      "dev": true
-    },
-    "node_modules/licenses/node_modules/debug": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
-      "integrity": "sha1-IP9NJvXkIstoobrLu2EDmtjBwTA=",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/limit-it": {
       "version": "3.2.8",
       "resolved": "https://registry.npmjs.org/limit-it/-/limit-it-3.2.8.tgz",
@@ -8135,12 +6414,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-      "dev": true
-    },
     "node_modules/lodash.capitalize": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
@@ -8169,12 +6442,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
-      "dev": true
-    },
-    "node_modules/lodash.map": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
       "dev": true
     },
     "node_modules/lodash.memoize": {
@@ -8285,15 +6552,6 @@
         "loglevel": "^1.4.1"
       }
     },
-    "node_modules/longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -8325,27 +6583,6 @@
         "yallist": "^2.1.2"
       }
     },
-    "node_modules/make-dir": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-      "dev": true,
-      "dependencies": {
-        "pify": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/make-dir/node_modules/pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/make-plural": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
@@ -8364,37 +6601,6 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true,
       "optional": true
-    },
-    "node_modules/mana": {
-      "version": "0.1.41",
-      "resolved": "https://registry.npmjs.org/mana/-/mana-0.1.41.tgz",
-      "integrity": "sha1-fLE/cyGGaGVCKWNcT8Wxfib5O30=",
-      "dev": true,
-      "dependencies": {
-        "assign": ">=0.1.7",
-        "back": "1.0.x",
-        "diagnostics": "1.0.x",
-        "eventemitter3": "1.2.x",
-        "fusing": "1.0.x",
-        "millisecond": "0.1.x",
-        "request": "2.x.x"
-      }
-    },
-    "node_modules/mana/node_modules/emits": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/emits/-/emits-3.0.0.tgz",
-      "integrity": "sha1-MnUrupXhcHshlWI4Srm7ix/WL3A=",
-      "dev": true
-    },
-    "node_modules/mana/node_modules/fusing": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fusing/-/fusing-1.0.0.tgz",
-      "integrity": "sha1-VQwV12r5Jld4qgUezkTUAAoJjUU=",
-      "dev": true,
-      "dependencies": {
-        "emits": "3.0.x",
-        "predefine": "0.1.x"
-      }
     },
     "node_modules/map-obj": {
       "version": "4.1.0",
@@ -8711,24 +6917,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/millisecond": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/millisecond/-/millisecond-0.1.2.tgz",
-      "integrity": "sha1-bMWtOGJByrjniv+WT4cCjuyS2sU=",
-      "dev": true
-    },
-    "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true,
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/mime-db": {
@@ -9171,27 +7359,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/moment": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.17.0.tgz",
-      "integrity": "sha1-pMKS4CqsXd77Kabu0k9Rk43Tt08=",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/moment-timezone": {
-      "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.14.tgz",
-      "integrity": "sha1-TrOP+VOLgBCLpGekWPPtQmjM/LE=",
-      "dev": true,
-      "dependencies": {
-        "moment": ">= 2.9.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/months": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/months/-/months-1.2.0.tgz",
@@ -9205,12 +7372,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
-    },
-    "node_modules/mute-stream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
       "dev": true
     },
     "node_modules/natural-compare": {
@@ -9230,245 +7391,6 @@
       "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
       "integrity": "sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo=",
       "dev": true
-    },
-    "node_modules/netrc": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz",
-      "integrity": "sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ=",
-      "dev": true
-    },
-    "node_modules/new-public-commits": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/new-public-commits/-/new-public-commits-1.3.1.tgz",
-      "integrity": "sha1-TXdVuHPwuesl9piNb3OSK4HX8RU=",
-      "dev": true,
-      "dependencies": {
-        "check-more-types": "2.24.0",
-        "debug": "2.6.8",
-        "ggit": "2.0.2",
-        "lazy-ass": "1.6.0",
-        "pluralize": "6.0.0",
-        "simple-commit-message": "3.3.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/new-public-commits/node_modules/am-i-a-dependency": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/am-i-a-dependency/-/am-i-a-dependency-1.0.0.tgz",
-      "integrity": "sha1-fA4usSYEU1CFLibkT2eBs+04eRk=",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/new-public-commits/node_modules/bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
-      "dev": true
-    },
-    "node_modules/new-public-commits/node_modules/chdir-promise": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/chdir-promise/-/chdir-promise-0.4.1.tgz",
-      "integrity": "sha1-GIi7M3GWmcn7chOMB1VlA8SRPoU=",
-      "dev": true,
-      "dependencies": {
-        "check-more-types": "2.24.0",
-        "debug": "2.6.8",
-        "lazy-ass": "1.6.0",
-        "q": "1.5.0",
-        "spots": "0.5.0"
-      }
-    },
-    "node_modules/new-public-commits/node_modules/chdir-promise/node_modules/q": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
-      "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
-      }
-    },
-    "node_modules/new-public-commits/node_modules/commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-      "dev": true
-    },
-    "node_modules/new-public-commits/node_modules/debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/new-public-commits/node_modules/ggit": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ggit/-/ggit-2.0.2.tgz",
-      "integrity": "sha1-XIY2Sajar9QCDZHST7jNjxCQnhk=",
-      "dev": true,
-      "dependencies": {
-        "always-error": "1.0.0",
-        "bluebird": "3.5.0",
-        "chdir-promise": "0.4.1",
-        "check-more-types": "2.24.0",
-        "cli-table": "0.3.1",
-        "colors": "1.1.2",
-        "commander": "2.11.0",
-        "d3-helpers": "0.3.0",
-        "debug": "2.6.8",
-        "find-up": "2.1.0",
-        "glob": "7.1.2",
-        "lazy-ass": "1.6.0",
-        "lodash": "4.17.4",
-        "moment": "2.18.1",
-        "optimist": "0.6.1",
-        "pluralize": "6.0.0",
-        "q": "2.0.3",
-        "quote": "0.4.0",
-        "ramda": "0.24.1",
-        "semver": "5.4.1"
-      },
-      "bin": {
-        "ggit": "bin/ggit.js"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/new-public-commits/node_modules/glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/new-public-commits/node_modules/lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-      "dev": true
-    },
-    "node_modules/new-public-commits/node_modules/moment": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/new-public-commits/node_modules/pluralize": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-6.0.0.tgz",
-      "integrity": "sha1-2bUa+tl9PVEHXMHdupsTLKzMt7o=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/new-public-commits/node_modules/ramda": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
-      "integrity": "sha1-w7d1UZfzW43DUCIoJixMkd22uFc=",
-      "dev": true
-    },
-    "node_modules/new-public-commits/node_modules/semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/new-public-commits/node_modules/simple-commit-message": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/simple-commit-message/-/simple-commit-message-3.3.1.tgz",
-      "integrity": "sha512-TGODO8KgYQqd/Y/Ik1cdwUXp3mxvrWPBeB87xRzDnoru6dLsgaJkLxu9Db7+kjkbhvEMnnKbPgJb4h4iq1aHZw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "am-i-a-dependency": "1.0.0",
-        "check-more-types": "2.24.0",
-        "debug": "2.6.8",
-        "ggit": "1.23.1",
-        "hr": "0.1.3",
-        "inquirer": "0.12.0",
-        "inquirer-confirm": "0.2.2",
-        "largest-semantic-change": "1.0.0",
-        "lazy-ass": "1.6.0",
-        "semver": "5.4.1",
-        "word-wrap": "1.2.3"
-      },
-      "bin": {
-        "simple-commit-message": "bin/simple-wizard.js"
-      }
-    },
-    "node_modules/new-public-commits/node_modules/simple-commit-message/node_modules/ggit": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/ggit/-/ggit-1.23.1.tgz",
-      "integrity": "sha1-5RPC8iKmJJpG5NDfNUuGBLW67ts=",
-      "dev": true,
-      "dependencies": {
-        "always-error": "1.0.0",
-        "bluebird": "3.5.0",
-        "chdir-promise": "0.4.1",
-        "check-more-types": "2.24.0",
-        "cli-table": "0.3.1",
-        "colors": "1.1.2",
-        "commander": "2.11.0",
-        "d3-helpers": "0.3.0",
-        "debug": "2.6.8",
-        "find-up": "2.1.0",
-        "glob": "7.1.2",
-        "lazy-ass": "1.6.0",
-        "lodash": "3.10.1",
-        "moment": "2.18.1",
-        "optimist": "0.6.1",
-        "pluralize": "6.0.0",
-        "q": "2.0.3",
-        "quote": "0.4.0",
-        "ramda": "0.24.1",
-        "semver": "5.4.1"
-      },
-      "bin": {
-        "ggit": "bin/ggit.js",
-        "ggit-last": "bin/ggit-last"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/new-public-commits/node_modules/simple-commit-message/node_modules/lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-      "dev": true
-    },
-    "node_modules/new-public-commits/node_modules/spots": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/spots/-/spots-0.5.0.tgz",
-      "integrity": "sha1-t6oPGsOJpabVfCHpjaHVODlAX+E=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
     },
     "node_modules/nice-try": {
       "version": "1.0.5",
@@ -9818,83 +7740,6 @@
         "node": "6 >=6.2.0 || 8 || >=9.3.0"
       }
     },
-    "node_modules/npm-registry": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/npm-registry/-/npm-registry-0.1.13.tgz",
-      "integrity": "sha1-nl2LL9/Bq1mQ1H99674jHXmp6CI=",
-      "dev": true,
-      "dependencies": {
-        "debug": "0.8.x",
-        "extract-github": "0.0.x",
-        "licenses": "0.0.x",
-        "mana": "0.1.x",
-        "semver": "2.2.x"
-      }
-    },
-    "node_modules/npm-registry-client": {
-      "version": "0.2.31",
-      "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-0.2.31.tgz",
-      "integrity": "sha1-JKI+JOQyRmd8tIX4ORgp6VNlY9Q=",
-      "dev": true,
-      "dependencies": {
-        "chownr": "0",
-        "couch-login": "~0.1.18",
-        "graceful-fs": "~2.0.0",
-        "mkdirp": "~0.3.3",
-        "request": "2 >=2.25.0",
-        "retry": "0.6.0",
-        "rimraf": "~2",
-        "semver": "^2.2.1",
-        "slide": "~1.1.3"
-      },
-      "optionalDependencies": {
-        "npmlog": ""
-      }
-    },
-    "node_modules/npm-registry-client/node_modules/graceful-fs": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
-      "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
-      "deprecated": "please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/npm-registry-client/node_modules/mkdirp": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-      "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
-      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-      "dev": true
-    },
-    "node_modules/npm-registry-client/node_modules/semver": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
-      "integrity": "sha1-uYSPJdbPNjMwc+ye+IVtQvEjPlI=",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/npm-registry/node_modules/debug": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
-      "integrity": "sha1-IP9NJvXkIstoobrLu2EDmtjBwTA=",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/npm-registry/node_modules/semver": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz",
-      "integrity": "sha1-eUEYKz/8xYC/8cF5QqzfeVHA0hM=",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -9905,142 +7750,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/npm-utils": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/npm-utils/-/npm-utils-1.12.0.tgz",
-      "integrity": "sha1-ZJxbFFZuMx98awSIV9LEaidnnNk=",
-      "dev": true,
-      "dependencies": {
-        "chdir-promise": "0.4.0",
-        "check-more-types": "2.23.0",
-        "cross-spawn": "5.0.1",
-        "debug": "2.3.3",
-        "del": "2.2.2",
-        "ggit": "1.13.4",
-        "lazy-ass": "1.5.0",
-        "q": "2.0.3",
-        "registry-url": "3.1.0",
-        "repo-url": "1.0.0",
-        "user-home": "2.0.0",
-        "verbal-expressions": "0.2.1"
-      },
-      "bin": {
-        "set-auth-token-var-name": "bin/set-auth-token-var-name.js"
-      },
-      "engines": {
-        "node": ">0.4.0"
-      }
-    },
-    "node_modules/npm-utils/node_modules/bluebird": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz",
-      "integrity": "sha1-AdqNgh2HgT0ViWfnQ9X+bGLPjA8=",
-      "dev": true
-    },
-    "node_modules/npm-utils/node_modules/chdir-promise": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/chdir-promise/-/chdir-promise-0.4.0.tgz",
-      "integrity": "sha1-RtxgLtGTGXRwFA8VJFmkOCz3mXQ=",
-      "dev": true,
-      "dependencies": {
-        "check-more-types": "2.23.0",
-        "debug": "^2.3.3",
-        "lazy-ass": "1.5.0",
-        "q": "1.1.2",
-        "spots": "0.4.0"
-      }
-    },
-    "node_modules/npm-utils/node_modules/chdir-promise/node_modules/q": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
-      "integrity": "sha1-Y1fikSBnAdmfGXq4TlforRlvKok=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
-      }
-    },
-    "node_modules/npm-utils/node_modules/check-more-types": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.23.0.tgz",
-      "integrity": "sha1-YiYmTTCxCVqhwKW4dO291dLQpm8=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/npm-utils/node_modules/cross-spawn": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.0.1.tgz",
-      "integrity": "sha1-o7uzAtsil8vqPATt82lB9GE6o5k=",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      }
-    },
-    "node_modules/npm-utils/node_modules/debug": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-      "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-      "dev": true,
-      "dependencies": {
-        "ms": "0.7.2"
-      }
-    },
-    "node_modules/npm-utils/node_modules/ggit": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/ggit/-/ggit-1.13.4.tgz",
-      "integrity": "sha1-UC53EGkYUj+gK4iv1Pe7ef35bTg=",
-      "dev": true,
-      "dependencies": {
-        "bluebird": "3.4.6",
-        "chdir-promise": "0.4.0",
-        "check-more-types": "2.23.0",
-        "cli-table": "0.3.1",
-        "colors": "1.1.2",
-        "commander": "2.9.0",
-        "d3-helpers": "0.3.0",
-        "debug": "2.3.3",
-        "glob": "7.1.1",
-        "lazy-ass": "1.5.0",
-        "lodash": "3.10.1",
-        "moment": "2.17.0",
-        "optimist": "0.6.1",
-        "q": "2.0.3",
-        "quote": "0.4.0",
-        "ramda": "0.9.1"
-      },
-      "bin": {
-        "ggit": "bin/ggit.js",
-        "ggit-last": "bin/ggit-last"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/npm-utils/node_modules/lazy-ass": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.5.0.tgz",
-      "integrity": "sha1-yhW+JDx8R1uFZc2/oPnC83TyoB0=",
-      "dev": true,
-      "engines": {
-        "node": "> 0.8"
-      }
-    },
-    "node_modules/npm-utils/node_modules/ms": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-      "dev": true
-    },
-    "node_modules/npm-utils/node_modules/ramda": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.9.1.tgz",
-      "integrity": "sha1-zJFNw6gsYI0AMJAgN4fD9oJsHYc=",
-      "dev": true
     },
     "node_modules/npm/node_modules/abbrev": {
       "version": "1.1.1",
@@ -14399,19 +12108,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
-      }
-    },
     "node_modules/number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -14446,18 +12142,6 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-keys": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.2.0.tgz",
-      "integrity": "sha1-zd7AKZiwkb5CvxA1rjLknxy26mc=",
-      "deprecated": "Please update to the latest object-keys",
-      "dev": true,
-      "dependencies": {
-        "foreach": "~2.0.1",
-        "indexof": "~0.0.1",
-        "is": "~0.2.6"
       }
     },
     "node_modules/object.assign": {
@@ -14558,15 +12242,6 @@
       "dev": true,
       "dependencies": {
         "deffy": "^2.0.0"
-      }
-    },
-    "node_modules/onetime": {
-      "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/optimist": {
@@ -14856,12 +12531,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parse-github-repo-url": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.0.tgz",
-      "integrity": "sha1-KGxT4smWLgZBZJ7jrJUI/KTdlZw=",
-      "dev": true
-    },
     "node_modules/parse-it": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/parse-it/-/parse-it-1.0.8.tgz",
@@ -14961,27 +12630,6 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "dependencies": {
-        "pinkie": "^2.0.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15187,510 +12835,6 @@
       "integrity": "sha1-zqz9q0q/NT16DyqqLB/Hs/lBO6M=",
       "dev": true
     },
-    "node_modules/pre-git": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/pre-git/-/pre-git-3.17.1.tgz",
-      "integrity": "sha512-/UH/OXKadgcm+7AvK7yNw5jxhN14/NSZ7rq8RgtJvX/KUjGtYQYx7UEAKIZtMjYZDO53nFpDVDr7SQzpVV55lA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "bluebird": "3.5.1",
-        "chalk": "2.3.2",
-        "check-more-types": "2.24.0",
-        "conventional-commit-message": "1.1.0",
-        "cz-conventional-changelog": "2.1.0",
-        "debug": "3.1.0",
-        "ggit": "2.4.2",
-        "inquirer": "3.3.0",
-        "lazy-ass": "1.6.0",
-        "require-relative": "0.8.7",
-        "shelljs": "0.8.1",
-        "simple-commit-message": "4.0.3",
-        "validate-commit-msg": "2.14.0",
-        "word-wrap": "1.2.3"
-      },
-      "bin": {
-        "_pre-git-helpers": "bin/_pre-git-helpers",
-        "commit-msg": "bin/commit-msg",
-        "commit-wizard": "bin/commit-wizard",
-        "post-checkout": "bin/post-checkout",
-        "post-commit": "bin/post-commit",
-        "post-merge": "bin/post-merge",
-        "pre-commit": "bin/pre-commit",
-        "pre-push": "bin/pre-push"
-      },
-      "engines": {
-        "node": "> 0.8.*"
-      }
-    },
-    "node_modules/pre-git/node_modules/ansi-escapes": {
-      "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pre-git/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pre-git/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pre-git/node_modules/bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-      "dev": true
-    },
-    "node_modules/pre-git/node_modules/chalk": {
-      "version": "2.3.2",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-      "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pre-git/node_modules/cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "dev": true,
-      "dependencies": {
-        "restore-cursor": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pre-git/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/pre-git/node_modules/debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/pre-git/node_modules/figures": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-      "dev": true,
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pre-git/node_modules/inquirer": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^2.0.4",
-        "figures": "^2.0.0",
-        "lodash": "^4.3.0",
-        "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rx-lite": "^4.0.8",
-        "rx-lite-aggregates": "^4.0.8",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
-        "through": "^2.3.6"
-      }
-    },
-    "node_modules/pre-git/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pre-git/node_modules/largest-semantic-change": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/largest-semantic-change/-/largest-semantic-change-1.1.0.tgz",
-      "integrity": "sha1-R/W+AAaqNENH0+d2lRoD1caS0v0=",
-      "dev": true,
-      "dependencies": {
-        "check-more-types": "2.23.0",
-        "lazy-ass": "1.5.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pre-git/node_modules/largest-semantic-change/node_modules/check-more-types": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.23.0.tgz",
-      "integrity": "sha1-YiYmTTCxCVqhwKW4dO291dLQpm8=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/pre-git/node_modules/largest-semantic-change/node_modules/lazy-ass": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.5.0.tgz",
-      "integrity": "sha1-yhW+JDx8R1uFZc2/oPnC83TyoB0=",
-      "dev": true,
-      "engines": {
-        "node": "> 0.8"
-      }
-    },
-    "node_modules/pre-git/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
-    "node_modules/pre-git/node_modules/mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-      "dev": true
-    },
-    "node_modules/pre-git/node_modules/onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "dev": true,
-      "dependencies": {
-        "mimic-fn": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pre-git/node_modules/restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "dev": true,
-      "dependencies": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pre-git/node_modules/run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "dev": true,
-      "dependencies": {
-        "is-promise": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/pre-git/node_modules/rx-lite": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
-    },
-    "node_modules/pre-git/node_modules/shelljs": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.1.tgz",
-      "integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pre-git/node_modules/simple-commit-message": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/simple-commit-message/-/simple-commit-message-4.0.3.tgz",
-      "integrity": "sha512-eC4PcOUQJLIQTSxFM2qzTetbK9excIlRVu4DMQ1HaVjdfLJ7U1QEyyiLgIAhlcf7cnLol9qev1PSTlcZmj9dxg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "am-i-a-dependency": "1.1.2",
-        "check-more-types": "2.24.0",
-        "debug": "3.1.0",
-        "ggit": "2.4.2",
-        "hr": "0.1.3",
-        "inquirer": "0.12.0",
-        "inquirer-confirm": "0.2.2",
-        "largest-semantic-change": "1.1.0",
-        "lazy-ass": "1.6.0",
-        "semver": "5.5.0",
-        "word-wrap": "1.2.3"
-      },
-      "bin": {
-        "simple-commit-message": "bin/simple-wizard.js"
-      }
-    },
-    "node_modules/pre-git/node_modules/simple-commit-message/node_modules/ansi-escapes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pre-git/node_modules/simple-commit-message/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pre-git/node_modules/simple-commit-message/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pre-git/node_modules/simple-commit-message/node_modules/chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pre-git/node_modules/simple-commit-message/node_modules/cli-cursor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true,
-      "dependencies": {
-        "restore-cursor": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pre-git/node_modules/simple-commit-message/node_modules/figures": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true,
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pre-git/node_modules/simple-commit-message/node_modules/inquirer": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-      "dev": true,
-      "dependencies": {
-        "ansi-escapes": "^1.1.0",
-        "ansi-regex": "^2.0.0",
-        "chalk": "^1.0.0",
-        "cli-cursor": "^1.0.1",
-        "cli-width": "^2.0.0",
-        "figures": "^1.3.5",
-        "lodash": "^4.3.0",
-        "readline2": "^1.0.1",
-        "run-async": "^0.1.0",
-        "rx-lite": "^3.1.2",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.0",
-        "through": "^2.3.6"
-      }
-    },
-    "node_modules/pre-git/node_modules/simple-commit-message/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pre-git/node_modules/simple-commit-message/node_modules/onetime": {
-      "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pre-git/node_modules/simple-commit-message/node_modules/restore-cursor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true,
-      "dependencies": {
-        "exit-hook": "^1.0.0",
-        "onetime": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pre-git/node_modules/simple-commit-message/node_modules/run-async": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true,
-      "dependencies": {
-        "once": "^1.3.0"
-      }
-    },
-    "node_modules/pre-git/node_modules/simple-commit-message/node_modules/rx-lite": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
-      "dev": true
-    },
-    "node_modules/pre-git/node_modules/simple-commit-message/node_modules/string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true,
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pre-git/node_modules/simple-commit-message/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pre-git/node_modules/simple-commit-message/node_modules/supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/pre-git/node_modules/string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pre-git/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pre-git/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/predefine": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/predefine/-/predefine-0.1.2.tgz",
-      "integrity": "sha1-KqkrRJa8H4VU5DpF92v75Q0z038=",
-      "dev": true,
-      "dependencies": {
-        "extendible": "0.1.x"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -15698,15 +12842,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/prettier": {
@@ -16939,29 +14074,6 @@
         "once": "^1.3.0"
       }
     },
-    "node_modules/readline2": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "dev": true,
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "mute-stream": "0.0.5"
-      }
-    },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -17029,40 +14141,6 @@
       "dev": true,
       "engines": {
         "node": ">=6.5.0"
-      }
-    },
-    "node_modules/registry-auth-token": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
-      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
-      "dev": true,
-      "dependencies": {
-        "rc": "^1.1.6",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/registry-url": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-      "dev": true,
-      "dependencies": {
-        "rc": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/repo-url": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/repo-url/-/repo-url-1.0.0.tgz",
-      "integrity": "sha1-CIWXsSYH9VmLqkchNtxzj7TjBFI=",
-      "dev": true,
-      "dependencies": {
-        "silent-npm-registry-client": "0.0.0"
-      },
-      "bin": {
-        "repo-url": "bin/repo-url.js"
       }
     },
     "node_modules/request": {
@@ -17182,28 +14260,6 @@
         "lowercase-keys": "^1.0.0"
       }
     },
-    "node_modules/restore-cursor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true,
-      "dependencies": {
-        "exit-hook": "^1.0.0",
-        "onetime": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/retry": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz",
-      "integrity": "sha1-HAEHEyeab9Ho3vKK8MP/GHHKpTc=",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -17214,46 +14270,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/right-pad": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/right-pad/-/right-pad-1.0.1.tgz",
-      "integrity": "sha1-jKCMLLtbVedNr6lr9/0aJ9VoyNA=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.0.5"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/run-async": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true,
-      "dependencies": {
-        "once": "^1.3.0"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
       "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
-      "dev": true
-    },
-    "node_modules/rx": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz",
-      "integrity": "sha1-Ia3H2A8CACr1Da6X/Z2/JIdV9WY=",
       "dev": true
     },
     "node_modules/rx-lite": {
@@ -17816,27 +14836,6 @@
         "semver": "bin/semver"
       }
     },
-    "node_modules/semver-diff": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-      "dev": true,
-      "dependencies": {
-        "semver": "^5.0.3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/semver-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz",
-      "integrity": "sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -17956,777 +14955,6 @@
       }
     },
     "node_modules/signale/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/silent-npm-registry-client": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/silent-npm-registry-client/-/silent-npm-registry-client-0.0.0.tgz",
-      "integrity": "sha1-gFAVIt8MGswsIRJWUm8PG5jbsN8=",
-      "dev": true,
-      "dependencies": {
-        "npm-registry-client": "~0.2.26",
-        "xtend": "~2.0.6"
-      }
-    },
-    "node_modules/silent-npm-registry-client/node_modules/xtend": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.0.6.tgz",
-      "integrity": "sha1-XqZXptukRwacLlnFihE4ywxebO4=",
-      "dev": true,
-      "dependencies": {
-        "is-object": "~0.1.2",
-        "object-keys": "~0.2.0"
-      },
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
-    "node_modules/simple-changelog": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/simple-changelog/-/simple-changelog-1.1.3.tgz",
-      "integrity": "sha1-gMKZjo4RNussxIn/vC/cz7K3guE=",
-      "dev": true,
-      "dependencies": {
-        "check-more-types": "2.24.0",
-        "common-tags": "1.4.0",
-        "debug": "2.6.8",
-        "ggit": "2.0.2",
-        "lazy-ass": "1.6.0",
-        "new-public-commits": "1.3.1",
-        "ramda": "0.24.1",
-        "simple-commit-message": "3.3.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/simple-changelog/node_modules/am-i-a-dependency": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/am-i-a-dependency/-/am-i-a-dependency-1.0.0.tgz",
-      "integrity": "sha1-fA4usSYEU1CFLibkT2eBs+04eRk=",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/simple-changelog/node_modules/bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
-      "dev": true
-    },
-    "node_modules/simple-changelog/node_modules/chdir-promise": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/chdir-promise/-/chdir-promise-0.4.1.tgz",
-      "integrity": "sha1-GIi7M3GWmcn7chOMB1VlA8SRPoU=",
-      "dev": true,
-      "dependencies": {
-        "check-more-types": "2.24.0",
-        "debug": "2.6.8",
-        "lazy-ass": "1.6.0",
-        "q": "1.5.0",
-        "spots": "0.5.0"
-      }
-    },
-    "node_modules/simple-changelog/node_modules/chdir-promise/node_modules/q": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
-      "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
-      }
-    },
-    "node_modules/simple-changelog/node_modules/commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-      "dev": true
-    },
-    "node_modules/simple-changelog/node_modules/debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/simple-changelog/node_modules/ggit": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ggit/-/ggit-2.0.2.tgz",
-      "integrity": "sha1-XIY2Sajar9QCDZHST7jNjxCQnhk=",
-      "dev": true,
-      "dependencies": {
-        "always-error": "1.0.0",
-        "bluebird": "3.5.0",
-        "chdir-promise": "0.4.1",
-        "check-more-types": "2.24.0",
-        "cli-table": "0.3.1",
-        "colors": "1.1.2",
-        "commander": "2.11.0",
-        "d3-helpers": "0.3.0",
-        "debug": "2.6.8",
-        "find-up": "2.1.0",
-        "glob": "7.1.2",
-        "lazy-ass": "1.6.0",
-        "lodash": "4.17.4",
-        "moment": "2.18.1",
-        "optimist": "0.6.1",
-        "pluralize": "6.0.0",
-        "q": "2.0.3",
-        "quote": "0.4.0",
-        "ramda": "0.24.1",
-        "semver": "5.4.1"
-      },
-      "bin": {
-        "ggit": "bin/ggit.js"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/simple-changelog/node_modules/glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/simple-changelog/node_modules/lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-      "dev": true
-    },
-    "node_modules/simple-changelog/node_modules/moment": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/simple-changelog/node_modules/pluralize": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-6.0.0.tgz",
-      "integrity": "sha1-2bUa+tl9PVEHXMHdupsTLKzMt7o=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/simple-changelog/node_modules/ramda": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
-      "integrity": "sha1-w7d1UZfzW43DUCIoJixMkd22uFc=",
-      "dev": true
-    },
-    "node_modules/simple-changelog/node_modules/semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/simple-changelog/node_modules/simple-commit-message": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/simple-commit-message/-/simple-commit-message-3.3.1.tgz",
-      "integrity": "sha512-TGODO8KgYQqd/Y/Ik1cdwUXp3mxvrWPBeB87xRzDnoru6dLsgaJkLxu9Db7+kjkbhvEMnnKbPgJb4h4iq1aHZw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "am-i-a-dependency": "1.0.0",
-        "check-more-types": "2.24.0",
-        "debug": "2.6.8",
-        "ggit": "1.23.1",
-        "hr": "0.1.3",
-        "inquirer": "0.12.0",
-        "inquirer-confirm": "0.2.2",
-        "largest-semantic-change": "1.0.0",
-        "lazy-ass": "1.6.0",
-        "semver": "5.4.1",
-        "word-wrap": "1.2.3"
-      },
-      "bin": {
-        "simple-commit-message": "bin/simple-wizard.js"
-      }
-    },
-    "node_modules/simple-changelog/node_modules/simple-commit-message/node_modules/ggit": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/ggit/-/ggit-1.23.1.tgz",
-      "integrity": "sha1-5RPC8iKmJJpG5NDfNUuGBLW67ts=",
-      "dev": true,
-      "dependencies": {
-        "always-error": "1.0.0",
-        "bluebird": "3.5.0",
-        "chdir-promise": "0.4.1",
-        "check-more-types": "2.24.0",
-        "cli-table": "0.3.1",
-        "colors": "1.1.2",
-        "commander": "2.11.0",
-        "d3-helpers": "0.3.0",
-        "debug": "2.6.8",
-        "find-up": "2.1.0",
-        "glob": "7.1.2",
-        "lazy-ass": "1.6.0",
-        "lodash": "3.10.1",
-        "moment": "2.18.1",
-        "optimist": "0.6.1",
-        "pluralize": "6.0.0",
-        "q": "2.0.3",
-        "quote": "0.4.0",
-        "ramda": "0.24.1",
-        "semver": "5.4.1"
-      },
-      "bin": {
-        "ggit": "bin/ggit.js",
-        "ggit-last": "bin/ggit-last"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/simple-changelog/node_modules/simple-commit-message/node_modules/lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-      "dev": true
-    },
-    "node_modules/simple-changelog/node_modules/spots": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/spots/-/spots-0.5.0.tgz",
-      "integrity": "sha1-t6oPGsOJpabVfCHpjaHVODlAX+E=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/simple-commit-message": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/simple-commit-message/-/simple-commit-message-4.1.3.tgz",
-      "integrity": "sha512-6L9cZeHWfHkPgjetER7D65SnWqb9S8txZ9K9xDvxQ+5uCPWhruN24wq0iZXZq0JDDdtPtW2oEV8Wia6P6nOtYg==",
-      "dev": true,
-      "dependencies": {
-        "check-more-types": "2.24.0",
-        "debug": "4.3.2",
-        "ggit": "2.4.12",
-        "hr": "0.1.3",
-        "inquirer": "6.5.2",
-        "inquirer-confirm": "2.0.7",
-        "largest-semantic-change": "1.1.0",
-        "lazy-ass": "1.6.0",
-        "semver": "5.7.1",
-        "word-wrap": "1.2.3"
-      },
-      "bin": {
-        "simple-commit-message": "bin/simple-wizard.js"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/ansi-escapes": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-      "dev": true
-    },
-    "node_modules/simple-commit-message/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
-    },
-    "node_modules/simple-commit-message/node_modules/cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "dev": true,
-      "dependencies": {
-        "restore-cursor": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/colors": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
-      "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/commander": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-      "dev": true
-    },
-    "node_modules/simple-commit-message/node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dev": true,
-      "dependencies": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/figures": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-      "dev": true,
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/ggit": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/ggit/-/ggit-2.4.12.tgz",
-      "integrity": "sha512-29DxkCEmqhXNk+JrV8GNQ+IY8OaJ1J2jC+B/vPvOk7CWs/2K8uX2DQeMlnFy7S+NeJrTNcLWfPJDdi6IflDt/A==",
-      "dev": true,
-      "dependencies": {
-        "always-error": "1.0.0",
-        "bluebird": "3.5.1",
-        "chdir-promise": "0.6.2",
-        "check-more-types": "2.24.0",
-        "cli-table": "0.3.1",
-        "colors": "1.3.2",
-        "commander": "2.17.1",
-        "d3-helpers": "0.3.0",
-        "debug": "3.2.6",
-        "find-up": "3.0.0",
-        "glob": "7.1.3",
-        "lazy-ass": "1.6.0",
-        "lodash": "4.17.15",
-        "moment": "2.23.0",
-        "moment-timezone": "0.5.23",
-        "optimist": "0.6.1",
-        "pluralize": "7.0.0",
-        "q": "2.0.3",
-        "quote": "0.4.0",
-        "ramda": "0.26.1",
-        "semver": "5.6.0"
-      },
-      "bin": {
-        "ggit": "bin/ggit.js"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/ggit/node_modules/debug": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
-      "dev": true,
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/ggit/node_modules/semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/inquirer": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
-      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-escapes": "^3.2.0",
-        "chalk": "^2.4.2",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^2.0.0",
-        "lodash": "^4.17.12",
-        "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^5.1.0",
-        "through": "^2.3.6"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/inquirer-confirm": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/inquirer-confirm/-/inquirer-confirm-2.0.7.tgz",
-      "integrity": "sha512-H617sAqikrmgHpykbotLqnXK4lsXIJRMbnBATZ1JeoNPGJD1KyPG4UpWme35BZsMjWOkDcEqH+DdWYqYSCgA3g==",
-      "dev": true,
-      "dependencies": {
-        "inquirer": "6.5.2"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/largest-semantic-change": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/largest-semantic-change/-/largest-semantic-change-1.1.0.tgz",
-      "integrity": "sha1-R/W+AAaqNENH0+d2lRoD1caS0v0=",
-      "dev": true,
-      "dependencies": {
-        "check-more-types": "2.23.0",
-        "lazy-ass": "1.5.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/largest-semantic-change/node_modules/check-more-types": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.23.0.tgz",
-      "integrity": "sha1-YiYmTTCxCVqhwKW4dO291dLQpm8=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/largest-semantic-change/node_modules/lazy-ass": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.5.0.tgz",
-      "integrity": "sha1-yhW+JDx8R1uFZc2/oPnC83TyoB0=",
-      "dev": true,
-      "engines": {
-        "node": "> 0.8"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
-    },
-    "node_modules/simple-commit-message/node_modules/moment": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.23.0.tgz",
-      "integrity": "sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/moment-timezone": {
-      "version": "0.5.23",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.23.tgz",
-      "integrity": "sha512-WHFH85DkCfiNMDX5D3X7hpNH3/PUhjTGcD0U1SgfBGZxJ3qUmJh5FdvaFjcClxOvB3rzdfj4oRffbI38jEnC1w==",
-      "dev": true,
-      "dependencies": {
-        "moment": ">= 2.9.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/simple-commit-message/node_modules/mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-      "dev": true
-    },
-    "node_modules/simple-commit-message/node_modules/onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "dev": true,
-      "dependencies": {
-        "mimic-fn": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "dev": true,
-      "dependencies": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/run-async": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/string-width/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/strip-ansi/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/simple-commit-message/node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
@@ -19084,15 +15312,6 @@
         "xtend": "~4.0.1"
       }
     },
-    "node_modules/spots": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/spots/-/spots-0.4.0.tgz",
-      "integrity": "sha1-Ae7F78FDZp2dOiDj7si4y9mELfY=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -19191,12 +15410,6 @@
         "duplexer2": "~0.1.0",
         "readable-stream": "^2.0.2"
       }
-    },
-    "node_modules/stream-consume": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
-      "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg==",
-      "dev": true
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -19768,36 +15981,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/term-size": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-      "dev": true,
-      "dependencies": {
-        "execa": "^0.7.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/term-size/node_modules/execa": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/text-extensions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -19806,12 +15989,6 @@
       "engines": {
         "node": ">=0.10"
       }
-    },
-    "node_modules/text-hex": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz",
-      "integrity": "sha1-V4+8haapJjbkLdF7QdAhjM6esrM=",
-      "dev": true
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -19888,47 +16065,6 @@
       },
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/top-dependents": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/top-dependents/-/top-dependents-1.0.0.tgz",
-      "integrity": "sha1-+PdgEnymvQFlSs9xYObWAEzHH9A=",
-      "dev": true,
-      "dependencies": {
-        "check-more-types": "2.2.0",
-        "lazy-ass": "1.1.0",
-        "lodash": "3.10.1",
-        "npm-registry": "0.1.13",
-        "q": "1.4.1"
-      }
-    },
-    "node_modules/top-dependents/node_modules/check-more-types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.2.0.tgz",
-      "integrity": "sha1-9eKvg0XQquYXxONEbmX6NTx/Rrs=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/top-dependents/node_modules/lazy-ass": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.1.0.tgz",
-      "integrity": "sha1-Wlkb1Twu4FLMUXIn9kwnmIIdf0k=",
-      "dev": true,
-      "engines": {
-        "node": "> 0.8"
-      }
-    },
-    "node_modules/top-dependents/node_modules/q": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-      "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
       }
     },
     "node_modules/tough-cookie": {
@@ -20151,32 +16287,11 @@
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
-    "node_modules/unique-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-      "dev": true,
-      "dependencies": {
-        "crypto-random-string": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/universal-user-agent": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
       "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
       "dev": true
-    },
-    "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
     },
     "node_modules/update-notifier": {
       "version": "5.1.0",
@@ -20366,30 +16481,6 @@
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true
     },
-    "node_modules/url-parse-lax": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-      "dev": true,
-      "dependencies": {
-        "prepend-http": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/user-home": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "dev": true,
-      "dependencies": {
-        "os-homedir": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -20407,22 +16498,6 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
       "integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
       "dev": true
-    },
-    "node_modules/validate-commit-msg": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/validate-commit-msg/-/validate-commit-msg-2.14.0.tgz",
-      "integrity": "sha1-5Tg2kQEsuycNzAvCpO/+vhSJDqw=",
-      "deprecated": "Check out CommitLint which provides the same functionality with a more user-focused experience.",
-      "dev": true,
-      "dependencies": {
-        "conventional-commit-types": "^2.0.0",
-        "find-parent-dir": "^0.3.0",
-        "findup": "0.1.5",
-        "semver-regex": "1.0.0"
-      },
-      "bin": {
-        "validate-commit-msg": "lib/cli.js"
-      }
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -20442,15 +16517,6 @@
       "dependencies": {
         "chalk": "^1.1.1",
         "object-assign": "^4.0.1"
-      }
-    },
-    "node_modules/verbal-expressions": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/verbal-expressions/-/verbal-expressions-0.2.1.tgz",
-      "integrity": "sha1-KLhF92Ddn5HWvDUdLgu0j6lcba8=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/verror": {
@@ -20637,15 +16703,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/wordwrap": {
@@ -21736,24 +17793,6 @@
       "integrity": "sha512-vbAsWMVidKHi9Ji8wcpk4ftJBNaascKCxLiV3STxWwPVXkj+oaOUA81RN0lvDhEm0ynUl6C7UUhKGiruWIp7ZQ==",
       "dev": true
     },
-    "agent-base": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
-      "dev": true,
-      "requires": {
-        "extend": "~3.0.0",
-        "semver": "~5.0.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
-          "dev": true
-        }
-      }
-    },
     "aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -21795,12 +17834,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/always-error/-/always-error-1.0.0.tgz",
       "integrity": "sha1-lchAQs+obzjIbKbCzELAoBA0QbI=",
-      "dev": true
-    },
-    "am-i-a-dependency": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/am-i-a-dependency/-/am-i-a-dependency-1.1.2.tgz",
-      "integrity": "sha1-+dNCIwTW9kL4IeTEB1ZQNfYWfx8=",
       "dev": true
     },
     "ansi-align": {
@@ -21856,12 +17889,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
       "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
-      "dev": true
-    },
-    "ansi-escapes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "dev": true
     },
     "ansi-parser": {
@@ -21941,24 +17968,6 @@
         }
       }
     },
-    "aproba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "dev": true,
-      "optional": true
-    },
-    "are-we-there-yet": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      }
-    },
     "arg": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
@@ -22015,21 +18024,6 @@
         "is-string": "^1.0.7"
       }
     },
-    "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "^1.0.1"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
-    },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -22053,27 +18047,6 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
-    },
-    "assign": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/assign/-/assign-0.1.7.tgz",
-      "integrity": "sha1-5jv+Ooh7hjCRPCdmPkzJv/Hd0l8=",
-      "dev": true,
-      "requires": {
-        "fusing": "0.4.x"
-      },
-      "dependencies": {
-        "fusing": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/fusing/-/fusing-0.4.0.tgz",
-          "integrity": "sha1-yZBo9Uyj4R3AEYkCFSq/Nnq6Sk0=",
-          "dev": true,
-          "requires": {
-            "emits": "1.0.x",
-            "predefine": "0.1.x"
-          }
-        }
-      }
     },
     "astral-regex": {
       "version": "1.0.0",
@@ -22144,15 +18117,6 @@
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
-      }
-    },
-    "back": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/back/-/back-1.0.2.tgz",
-      "integrity": "sha1-qT9ebOaXKZhNWQGiuxbjsBpNY2k=",
-      "dev": true,
-      "requires": {
-        "xtend": "^4.0.0"
       }
     },
     "balanced-match": {
@@ -22662,12 +18626,6 @@
         }
       }
     },
-    "capture-stack-trace": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-      "dev": true
-    },
     "cardinal": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
@@ -22730,12 +18688,6 @@
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
       "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA="
-    },
-    "chownr": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-0.0.2.tgz",
-      "integrity": "sha1-L5rr90b5CAjOAGB7crpztBYExIU=",
-      "dev": true
     },
     "ci-info": {
       "version": "2.0.0",
@@ -22807,21 +18759,6 @@
             "typpy": "2.0.0"
           }
         }
-      }
-    },
-    "cli-boxes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
-      "dev": true
-    },
-    "cli-cursor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "^1.0.1"
       }
     },
     "cli-table": {
@@ -22923,58 +18860,11 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
-    "color": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/color/-/color-0.8.0.tgz",
-      "integrity": "sha1-iQwHw/1OZJU3Y4kRz2keVFi2/KU=",
-      "dev": true,
-      "requires": {
-        "color-convert": "^0.5.0",
-        "color-string": "^0.3.0"
-      }
-    },
-    "color-convert": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
-      "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=",
-      "dev": true
-    },
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
-    },
-    "color-string": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-      "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-      "dev": true,
-      "requires": {
-        "color-name": "^1.0.0"
-      }
-    },
-    "colornames": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz",
-      "integrity": "sha1-2BH9bIT1kClJmorEQ2ICk1uSvjE=",
-      "dev": true
-    },
-    "colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-      "dev": true
-    },
-    "colorspace": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.0.1.tgz",
-      "integrity": "sha1-yZx5btMRKLmHalLh7l7gOkpxl0k=",
-      "dev": true,
-      "requires": {
-        "color": "0.8.x",
-        "text-hex": "0.0.x"
-      }
     },
     "combined-stream": {
       "version": "1.0.6",
@@ -22983,25 +18873,6 @@
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
-      }
-    },
-    "commander": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true,
-      "requires": {
-        "graceful-readlink": ">= 1.0.0"
-      }
-    },
-    "commit-closes": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commit-closes/-/commit-closes-1.0.1.tgz",
-      "integrity": "sha1-96rVyHy/0ZRTAgwZI3fBXdGsba4=",
-      "dev": true,
-      "requires": {
-        "check-more-types": "2.24.0",
-        "lazy-ass": "1.6.0"
       }
     },
     "common-tags": {
@@ -23087,13 +18958,6 @@
         }
       }
     },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true,
-      "optional": true
-    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
@@ -23149,53 +19013,6 @@
           "dev": true
         }
       }
-    },
-    "conventional-commit-message": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-commit-message/-/conventional-commit-message-1.1.0.tgz",
-      "integrity": "sha1-7OjGYaFo6YNpLh1aFIday1lRD2o=",
-      "dev": true,
-      "requires": {
-        "check-more-types": "2.3.0",
-        "cz-conventional-changelog": "1.1.5",
-        "lazy-ass": "1.3.0",
-        "word-wrap": "1.1.0"
-      },
-      "dependencies": {
-        "check-more-types": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.3.0.tgz",
-          "integrity": "sha1-uDl8adySo+ZF8YkywEWwnHRBnsQ=",
-          "dev": true
-        },
-        "cz-conventional-changelog": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-1.1.5.tgz",
-          "integrity": "sha1-Ck0VUMTi+2o67Y9s2FjCF2DhGbg=",
-          "dev": true,
-          "requires": {
-            "word-wrap": "^1.0.3"
-          }
-        },
-        "lazy-ass": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.3.0.tgz",
-          "integrity": "sha1-fQ0U7vPslwLG8wxg6oHxqNP5APs=",
-          "dev": true
-        },
-        "word-wrap": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.1.0.tgz",
-          "integrity": "sha1-NWFT1h0QYQ1gB4XF1wEojgrnZKY=",
-          "dev": true
-        }
-      }
-    },
-    "conventional-commit-types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-2.2.0.tgz",
-      "integrity": "sha1-XblXOdbCEqy+e29lahG5QLqmiUY=",
-      "dev": true
     },
     "conventional-commits-filter": {
       "version": "2.0.7",
@@ -23269,15 +19086,6 @@
         }
       }
     },
-    "couch-login": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/couch-login/-/couch-login-0.1.20.tgz",
-      "integrity": "sha1-AHxw74AInbrm9Z7u7DdIB5mzlZU=",
-      "dev": true,
-      "requires": {
-        "request": "2 >=2.25.0"
-      }
-    },
     "couleurs": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/couleurs/-/couleurs-5.2.1.tgz",
@@ -23297,15 +19105,6 @@
         }
       }
     },
-    "create-error-class": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "dev": true,
-      "requires": {
-        "capture-stack-trace": "^1.0.0"
-      }
-    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -23317,12 +19116,6 @@
         "which": "^1.2.9"
       }
     },
-    "crypto-random-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
-      "dev": true
-    },
     "custom-return": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/custom-return/-/custom-return-1.0.10.tgz",
@@ -23330,19 +19123,6 @@
       "dev": true,
       "requires": {
         "noop6": "^1.0.0"
-      }
-    },
-    "cz-conventional-changelog": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-2.1.0.tgz",
-      "integrity": "sha1-L0vHOQ4yROTfKT5ro1Hkx0Cnx2Q=",
-      "dev": true,
-      "requires": {
-        "conventional-commit-types": "^2.0.0",
-        "lodash.map": "^4.5.1",
-        "longest": "^1.0.1",
-        "right-pad": "^1.0.1",
-        "word-wrap": "^1.0.3"
       }
     },
     "d3-helpers": {
@@ -23524,33 +19304,11 @@
         }
       }
     },
-    "del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true,
-      "requires": {
-        "globby": "^5.0.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "rimraf": "^2.2.8"
-      }
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
-    },
-    "delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true,
-      "optional": true
     },
     "dependency-check": {
       "version": "4.1.0",
@@ -23699,17 +19457,6 @@
         "wrappy": "1"
       }
     },
-    "diagnostics": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.0.1.tgz",
-      "integrity": "sha1-rM2wgMgrsl0N1zQwqeaof7tDFUE=",
-      "dev": true,
-      "requires": {
-        "colorspace": "1.0.x",
-        "enabled": "1.0.x",
-        "kuler": "0.0.x"
-      }
-    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -23800,401 +19547,6 @@
         "esutils": "^2.0.2"
       }
     },
-    "dont-break": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/dont-break/-/dont-break-1.5.0.tgz",
-      "integrity": "sha1-nzsgBXme5cPlmjK689rPJtNG6Bs=",
-      "dev": true,
-      "requires": {
-        "chdir-promise": "0.4.0",
-        "check-more-types": "2.24.0",
-        "commander": "2.9.0",
-        "debug": "2.6.8",
-        "fs-extra": "^3.0.1",
-        "ggit": "1.15.1",
-        "hr": "0.1.3",
-        "lazy-ass": "1.6.0",
-        "lodash": "4.17.4",
-        "npm-registry": "0.1.13",
-        "npm-utils": "1.12.0",
-        "os-tmpdir": "1.0.2",
-        "q": "2.0.3",
-        "quote": "0.4.0",
-        "rimraf": "2.6.1",
-        "strip-json-comments": "2.0.1",
-        "top-dependents": "1.0.0",
-        "update-notifier": "2.1.0"
-      },
-      "dependencies": {
-        "ansi-align": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-          "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-          "dev": true,
-          "requires": {
-            "string-width": "^2.0.0"
-          }
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "bluebird": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
-          "dev": true
-        },
-        "boxen": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-          "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
-          "dev": true,
-          "requires": {
-            "ansi-align": "^2.0.0",
-            "camelcase": "^4.0.0",
-            "chalk": "^2.0.1",
-            "cli-boxes": "^1.0.0",
-            "string-width": "^2.0.0",
-            "term-size": "^1.2.0",
-            "widest-line": "^2.0.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.4.1",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-              "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            }
-          }
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
-        "chdir-promise": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chdir-promise/-/chdir-promise-0.4.0.tgz",
-          "integrity": "sha1-RtxgLtGTGXRwFA8VJFmkOCz3mXQ=",
-          "dev": true,
-          "requires": {
-            "check-more-types": "2.23.0",
-            "debug": "^2.3.3",
-            "lazy-ass": "1.5.0",
-            "q": "1.1.2",
-            "spots": "0.4.0"
-          },
-          "dependencies": {
-            "check-more-types": {
-              "version": "2.23.0",
-              "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.23.0.tgz",
-              "integrity": "sha1-YiYmTTCxCVqhwKW4dO291dLQpm8=",
-              "dev": true
-            },
-            "lazy-ass": {
-              "version": "1.5.0",
-              "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.5.0.tgz",
-              "integrity": "sha1-yhW+JDx8R1uFZc2/oPnC83TyoB0=",
-              "dev": true
-            },
-            "q": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
-              "integrity": "sha1-Y1fikSBnAdmfGXq4TlforRlvKok=",
-              "dev": true
-            }
-          }
-        },
-        "color-convert": {
-          "version": "1.9.2",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
-          "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.1"
-          }
-        },
-        "color-name": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
-          "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
-          "dev": true
-        },
-        "configstore": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
-          "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
-          "dev": true,
-          "requires": {
-            "dot-prop": "^4.1.0",
-            "graceful-fs": "^4.1.2",
-            "make-dir": "^1.0.0",
-            "unique-string": "^1.0.0",
-            "write-file-atomic": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "dot-prop": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-          "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-          "dev": true,
-          "requires": {
-            "is-obj": "^1.0.0"
-          }
-        },
-        "ggit": {
-          "version": "1.15.1",
-          "resolved": "https://registry.npmjs.org/ggit/-/ggit-1.15.1.tgz",
-          "integrity": "sha1-gNVS6OFxLJgF/luhzxGaTn472Zg=",
-          "dev": true,
-          "requires": {
-            "bluebird": "3.5.0",
-            "chdir-promise": "0.4.0",
-            "check-more-types": "2.24.0",
-            "cli-table": "0.3.1",
-            "colors": "1.1.2",
-            "commander": "2.9.0",
-            "d3-helpers": "0.3.0",
-            "debug": "2.6.3",
-            "glob": "7.1.1",
-            "lazy-ass": "1.6.0",
-            "lodash": "3.10.1",
-            "moment": "2.18.1",
-            "optimist": "0.6.1",
-            "q": "2.0.3",
-            "quote": "0.4.0",
-            "ramda": "0.9.1"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.3",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
-              "integrity": "sha1-D364wwll7AjHKsz6ATDIt5mEFB0=",
-              "dev": true,
-              "requires": {
-                "ms": "0.7.2"
-              }
-            },
-            "lodash": {
-              "version": "3.10.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-              "dev": true
-            },
-            "ms": {
-              "version": "0.7.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-              "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-              "dev": true
-            }
-          }
-        },
-        "got": {
-          "version": "6.7.1",
-          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-          "dev": true,
-          "requires": {
-            "create-error-class": "^3.0.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "unzip-response": "^2.0.1",
-            "url-parse-lax": "^1.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "latest-version": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-          "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
-          "dev": true,
-          "requires": {
-            "package-json": "^4.0.0"
-          }
-        },
-        "lazy-req": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-2.0.0.tgz",
-          "integrity": "sha1-yUUKNj7N2i5vDHATKtTzf48G8rQ=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
-        "moment": {
-          "version": "2.18.1",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-          "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
-          "dev": true
-        },
-        "package-json": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-          "dev": true,
-          "requires": {
-            "got": "^6.7.1",
-            "registry-auth-token": "^3.0.1",
-            "registry-url": "^3.0.3",
-            "semver": "^5.1.0"
-          }
-        },
-        "ramda": {
-          "version": "0.9.1",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.9.1.tgz",
-          "integrity": "sha1-zJFNw6gsYI0AMJAgN4fD9oJsHYc=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "timed-out": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-          "dev": true
-        },
-        "unzip-response": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-          "dev": true
-        },
-        "update-notifier": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.1.0.tgz",
-          "integrity": "sha1-7AweU1NrdmR6JLd8uDlm2TFRI9k=",
-          "dev": true,
-          "requires": {
-            "boxen": "^1.0.0",
-            "chalk": "^1.0.0",
-            "configstore": "^3.0.0",
-            "is-npm": "^1.0.0",
-            "latest-version": "^3.0.0",
-            "lazy-req": "^2.0.0",
-            "semver-diff": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
-          }
-        },
-        "widest-line": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
-          "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
-          "dev": true,
-          "requires": {
-            "string-width": "^2.1.1"
-          }
-        },
-        "write-file-atomic": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-          "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "xdg-basedir": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-          "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
-          "dev": true
-        }
-      }
-    },
-    "dont-crack": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/dont-crack/-/dont-crack-1.2.1.tgz",
-      "integrity": "sha1-yheZXEsD1O5JC7Jn0VMsM3iwaIk=",
-      "dev": true,
-      "requires": {
-        "always-error": "^1.0.0",
-        "check-more-types": "2.24.0",
-        "debug": "2.6.8",
-        "dont-break": "1.5.0",
-        "lazy-ass": "1.6.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
     "dot-prop": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
@@ -24237,26 +19589,11 @@
         "jsbn": "~0.1.0"
       }
     },
-    "emits": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/emits/-/emits-1.0.2.tgz",
-      "integrity": "sha1-2yDsZmgyUHHDE0QeMM/ipp6nOFk=",
-      "dev": true
-    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
-    },
-    "enabled": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
-      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
-      "dev": true,
-      "requires": {
-        "env-variable": "0.0.x"
-      }
     },
     "end-of-stream": {
       "version": "1.4.1",
@@ -24374,12 +19711,6 @@
           }
         }
       }
-    },
-    "env-variable": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.4.tgz",
-      "integrity": "sha512-+jpGxSWG4vr6gVxUHOc4p+ilPnql7NzZxOZBxNldsKGjCF+97df3CbuX7XMaDa5oAVkKQj4rKp38rYdC4VcpDg==",
-      "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
@@ -25175,12 +20506,6 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "eventemitter3": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
-      "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
-      "dev": true
-    },
     "exclude-arr": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/exclude-arr/-/exclude-arr-1.0.9.tgz",
@@ -25233,22 +20558,10 @@
         }
       }
     },
-    "exit-hook": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
-      "dev": true
-    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
-    },
-    "extendible": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/extendible/-/extendible-0.1.1.tgz",
-      "integrity": "sha1-4qN+2HEp+0+VM+io11BiMKU5yQU=",
       "dev": true
     },
     "external-editor": {
@@ -25261,12 +20574,6 @@
         "iconv-lite": "^0.4.17",
         "tmp": "^0.0.33"
       }
-    },
-    "extract-github": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/extract-github/-/extract-github-0.0.5.tgz",
-      "integrity": "sha1-9UJTbbjBm5g6O+yduW0u8qX/GoY=",
-      "dev": true
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -25315,16 +20622,6 @@
         "reusify": "^1.0.0"
       }
     },
-    "figures": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
-      }
-    },
     "file-entry-cache": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
@@ -25347,12 +20644,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fillo/-/fillo-1.0.11.tgz",
       "integrity": "sha512-3YWc82rxHEJUCMbHXxYwnu6X4zmOKjqVLtU0NsTOaPFj1lF8YaqodE+efvEPyq7kL5W8kT91OfO6KU1HVwBDzQ==",
-      "dev": true
-    },
-    "find-parent-dir": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
-      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
       "dev": true
     },
     "find-root": {
@@ -25383,30 +20674,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-2.0.0.tgz",
           "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==",
-          "dev": true
-        }
-      }
-    },
-    "findup": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
-      "integrity": "sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=",
-      "dev": true,
-      "requires": {
-        "colors": "~0.6.0-1",
-        "commander": "~2.1.0"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
-          "dev": true
-        },
-        "commander": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
-          "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
           "dev": true
         }
       }
@@ -25491,27 +20758,6 @@
       "integrity": "sha512-+8GbtQBwEqutP0v3uajDDoN64K2ehmHd0cjlghhxh0WpcfPzAIjPA03e1VvHlxL02FVGR0A6lwXsNQKn3H1RNQ==",
       "dev": true
     },
-    "follow-redirects": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
-      "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk=",
-      "dev": true,
-      "requires": {
-        "debug": "^2.2.0",
-        "stream-consume": "^0.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
     "for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -25520,12 +20766,6 @@
       "requires": {
         "is-callable": "^1.1.3"
       }
-    },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -25564,17 +20804,6 @@
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
-      }
-    },
-    "fs-extra": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
-      "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^3.0.0",
-        "universalify": "^0.1.0"
       }
     },
     "fs.realpath": {
@@ -25622,32 +20851,6 @@
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true
     },
-    "fusing": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/fusing/-/fusing-0.2.3.tgz",
-      "integrity": "sha1-0O76+YXSuv3tRK+LGFMW9uQp4ds=",
-      "dev": true,
-      "requires": {
-        "predefine": "0.1.x"
-      }
-    },
-    "gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
-    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -25671,12 +20874,6 @@
       "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
       "dev": true
     },
-    "get-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true
-    },
     "get-symbol-description": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
@@ -25694,96 +20891,6 @@
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
-      }
-    },
-    "ggit": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/ggit/-/ggit-2.4.2.tgz",
-      "integrity": "sha512-4pltyhG4cjVT1Nqs9pq8Iykc/lTibc4LKRUAxszA9+OgwpfGhbsFgzhtyXwh5AbiWZrBa87nIHzyVGlJoT4nCw==",
-      "dev": true,
-      "requires": {
-        "always-error": "1.0.0",
-        "bluebird": "3.5.1",
-        "chdir-promise": "0.6.2",
-        "check-more-types": "2.24.0",
-        "cli-table": "0.3.1",
-        "colors": "1.1.2",
-        "commander": "2.12.2",
-        "d3-helpers": "0.3.0",
-        "debug": "3.1.0",
-        "find-up": "2.1.0",
-        "glob": "7.1.2",
-        "lazy-ass": "1.6.0",
-        "lodash": "4.17.4",
-        "moment": "2.19.3",
-        "moment-timezone": "0.5.14",
-        "optimist": "0.6.1",
-        "pluralize": "7.0.0",
-        "q": "2.0.3",
-        "quote": "0.4.0",
-        "ramda": "0.25.0",
-        "semver": "5.4.1"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-          "dev": true
-        },
-        "commander": {
-          "version": "2.12.2",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
-          "dev": true
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
-        "moment": {
-          "version": "2.19.3",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.3.tgz",
-          "integrity": "sha1-vbmdJw1tf9p4zA+6zoVeJ/59pp8=",
-          "dev": true
-        },
-        "ramda": {
-          "version": "0.25.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
-          "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-          "dev": true
-        }
       }
     },
     "git-issues": {
@@ -25857,238 +20964,6 @@
         "git-up": "^1.0.0"
       }
     },
-    "github": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/github/-/github-9.2.0.tgz",
-      "integrity": "sha1-iohtxA3WNjZwfcr5nfPfJsWfFvw=",
-      "dev": true,
-      "requires": {
-        "follow-redirects": "0.0.7",
-        "https-proxy-agent": "^1.0.0",
-        "mime": "^1.2.11",
-        "netrc": "^0.1.4"
-      }
-    },
-    "github-post-release": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/github-post-release/-/github-post-release-1.13.1.tgz",
-      "integrity": "sha1-pJVqWfl4fs9DdpvWBzSsDLVXU6Q=",
-      "dev": true,
-      "requires": {
-        "am-i-a-dependency": "1.1.2",
-        "bluebird": "3.5.0",
-        "check-more-types": "2.24.0",
-        "commit-closes": "1.0.1",
-        "common-tags": "1.4.0",
-        "debug": "3.0.0",
-        "github": "9.2.0",
-        "github-url-from-git": "1.5.0",
-        "lazy-ass": "1.6.0",
-        "new-public-commits": "1.3.1",
-        "parse-github-repo-url": "1.4.0",
-        "pluralize": "6.0.0",
-        "ramda": "0.24.1",
-        "simple-changelog": "1.1.3",
-        "simple-commit-message": "3.3.1"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
-          "dev": true
-        },
-        "chdir-promise": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/chdir-promise/-/chdir-promise-0.4.1.tgz",
-          "integrity": "sha1-GIi7M3GWmcn7chOMB1VlA8SRPoU=",
-          "dev": true,
-          "requires": {
-            "check-more-types": "2.24.0",
-            "debug": "2.6.8",
-            "lazy-ass": "1.6.0",
-            "q": "1.5.0",
-            "spots": "0.5.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.8",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-              "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "q": {
-              "version": "1.5.0",
-              "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
-              "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
-              "dev": true
-            }
-          }
-        },
-        "commander": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-          "dev": true
-        },
-        "debug": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.0.0.tgz",
-          "integrity": "sha512-XQkHxxqbsCb+zFurCHbotmJZl5jXsxvkRt952pT6Hpo7LmjWAJF12d9/kqBg5owjbLADbBDli1olravjSiSg8g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ggit": {
-          "version": "1.23.1",
-          "resolved": "https://registry.npmjs.org/ggit/-/ggit-1.23.1.tgz",
-          "integrity": "sha1-5RPC8iKmJJpG5NDfNUuGBLW67ts=",
-          "dev": true,
-          "requires": {
-            "always-error": "1.0.0",
-            "bluebird": "3.5.0",
-            "chdir-promise": "0.4.1",
-            "check-more-types": "2.24.0",
-            "cli-table": "0.3.1",
-            "colors": "1.1.2",
-            "commander": "2.11.0",
-            "d3-helpers": "0.3.0",
-            "debug": "2.6.8",
-            "find-up": "2.1.0",
-            "glob": "7.1.2",
-            "lazy-ass": "1.6.0",
-            "lodash": "3.10.1",
-            "moment": "2.18.1",
-            "optimist": "0.6.1",
-            "pluralize": "6.0.0",
-            "q": "2.0.3",
-            "quote": "0.4.0",
-            "ramda": "0.24.1",
-            "semver": "5.4.1"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.8",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-              "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "moment": {
-          "version": "2.18.1",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-          "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
-          "dev": true
-        },
-        "pluralize": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-6.0.0.tgz",
-          "integrity": "sha1-2bUa+tl9PVEHXMHdupsTLKzMt7o=",
-          "dev": true
-        },
-        "ramda": {
-          "version": "0.24.1",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
-          "integrity": "sha1-w7d1UZfzW43DUCIoJixMkd22uFc=",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-          "dev": true
-        },
-        "simple-commit-message": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/simple-commit-message/-/simple-commit-message-3.3.1.tgz",
-          "integrity": "sha512-TGODO8KgYQqd/Y/Ik1cdwUXp3mxvrWPBeB87xRzDnoru6dLsgaJkLxu9Db7+kjkbhvEMnnKbPgJb4h4iq1aHZw==",
-          "dev": true,
-          "requires": {
-            "am-i-a-dependency": "1.0.0",
-            "check-more-types": "2.24.0",
-            "debug": "2.6.8",
-            "ggit": "1.23.1",
-            "hr": "0.1.3",
-            "inquirer": "0.12.0",
-            "inquirer-confirm": "0.2.2",
-            "largest-semantic-change": "1.0.0",
-            "lazy-ass": "1.6.0",
-            "semver": "5.4.1",
-            "word-wrap": "1.2.3"
-          },
-          "dependencies": {
-            "am-i-a-dependency": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/am-i-a-dependency/-/am-i-a-dependency-1.0.0.tgz",
-              "integrity": "sha1-fA4usSYEU1CFLibkT2eBs+04eRk=",
-              "dev": true
-            },
-            "debug": {
-              "version": "2.6.8",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-              "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
-          }
-        },
-        "spots": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/spots/-/spots-0.5.0.tgz",
-          "integrity": "sha1-t6oPGsOJpabVfCHpjaHVODlAX+E=",
-          "dev": true
-        }
-      }
-    },
-    "github-url-from-git": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
-      "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA=",
-      "dev": true
-    },
-    "githulk": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/githulk/-/githulk-0.0.7.tgz",
-      "integrity": "sha1-2Wyinw7EMRfFOOUh1mNWbqhLTv8=",
-      "dev": true,
-      "requires": {
-        "debug": "0.7.x",
-        "extract-github": "0.0.x",
-        "mana": "0.1.x"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
-          "dev": true
-        }
-      }
-    },
     "glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
@@ -26142,20 +21017,6 @@
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3"
-      }
-    },
-    "globby": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true,
-      "requires": {
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
       }
     },
     "gopd": {
@@ -26216,12 +21077,6 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
-    },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
       "dev": true
     },
     "growl": {
@@ -26362,13 +21217,6 @@
         "has-symbols": "^1.0.2"
       }
     },
-    "has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true,
-      "optional": true
-    },
     "has-yarn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
@@ -26391,12 +21239,6 @@
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "dev": true
-    },
-    "hr": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/hr/-/hr-0.1.3.tgz",
-      "integrity": "sha1-2aow9ZKdq/0LZbo5WTij4YTbyv4=",
       "dev": true
     },
     "http-cache-semantics": {
@@ -26436,28 +21278,6 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
-      }
-    },
-    "https-proxy-agent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
-      "dev": true,
-      "requires": {
-        "agent-base": "2",
-        "debug": "2",
-        "extend": "3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "human-signals": {
@@ -26534,12 +21354,6 @@
       "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
       "dev": true
     },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
-      "dev": true
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -26562,106 +21376,6 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
-    "inquirer": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "^1.1.0",
-        "ansi-regex": "^2.0.0",
-        "chalk": "^1.0.0",
-        "cli-cursor": "^1.0.1",
-        "cli-width": "^2.0.0",
-        "figures": "^1.3.5",
-        "lodash": "^4.3.0",
-        "readline2": "^1.0.1",
-        "run-async": "^0.1.0",
-        "rx-lite": "^3.1.2",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.0",
-        "through": "^2.3.6"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
-        }
-      }
-    },
-    "inquirer-confirm": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/inquirer-confirm/-/inquirer-confirm-0.2.2.tgz",
-      "integrity": "sha1-b0BtA3v52eRV7w+VOSnzV/6aiEg=",
-      "dev": true,
-      "requires": {
-        "bluebird": "2.9.24",
-        "inquirer": "0.8.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-          "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
-          "dev": true
-        },
-        "bluebird": {
-          "version": "2.9.24",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.24.tgz",
-          "integrity": "sha1-FKLnXwVIMj3DWqRA2SAHyhVOlnw=",
-          "dev": true
-        },
-        "cli-width": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
-          "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=",
-          "dev": true
-        },
-        "inquirer": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.2.tgz",
-          "integrity": "sha1-QVhlSOHF2bP4HfcyUDS6rKtvWKs=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^1.1.1",
-            "chalk": "^1.0.0",
-            "cli-width": "^1.0.1",
-            "figures": "^1.3.5",
-            "lodash": "^3.3.1",
-            "readline2": "^0.1.1",
-            "rx": "^2.4.3",
-            "through": "^2.3.6"
-          }
-        },
-        "mute-stream": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
-          "integrity": "sha1-qSGZYKbV1dBGWXruUSUsZlX3F34=",
-          "dev": true
-        },
-        "readline2": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
-          "integrity": "sha1-mUQ7pug7gw7zBRv9fcJBqCco1Wg=",
-          "dev": true,
-          "requires": {
-            "mute-stream": "0.0.4",
-            "strip-ansi": "^2.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-          "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^1.0.0"
-          }
-        }
-      }
-    },
     "internal-slot": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
@@ -26673,12 +21387,6 @@
         "side-channel": "^1.0.4"
       }
     },
-    "interpret": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
-      "dev": true
-    },
     "into-stream": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-5.1.1.tgz",
@@ -26688,12 +21396,6 @@
         "from2": "^2.3.0",
         "p-is-promise": "^3.0.0"
       }
-    },
-    "is": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/is/-/is-0.2.7.tgz",
-      "integrity": "sha1-OzSixI81mXLzUEKEkZOucmS2NWI=",
-      "dev": true
     },
     "is-array-buffer": {
       "version": "3.0.2",
@@ -26821,12 +21523,6 @@
       "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
       "dev": true
     },
-    "is-npm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
-      "dev": true
-    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -26842,42 +21538,6 @@
         "has-tostringtag": "^1.0.0"
       }
     },
-    "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true
-    },
-    "is-object": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-0.1.2.tgz",
-      "integrity": "sha1-AO+8CIFsM8/ErIJR0TLhDcZQmNc=",
-      "dev": true
-    },
-    "is-path-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-      "dev": true
-    },
-    "is-path-in-cwd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "^1.0.0"
-      }
-    },
-    "is-path-inside": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "^1.0.1"
-      }
-    },
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
@@ -26888,18 +21548,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "dev": true
-    },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
-    },
-    "is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true
     },
     "is-regex": {
@@ -26925,12 +21573,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
-      "dev": true
-    },
-    "is-retry-allowed": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
       "dev": true
     },
     "is-shared-array-buffer": {
@@ -27151,15 +21793,6 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
-    "jsonfile": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
-      "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -27212,39 +21845,6 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
-    },
-    "kuler": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz",
-      "integrity": "sha1-tmu0a5NOVQ9Z2BiEjgq7pPf1VTw=",
-      "dev": true,
-      "requires": {
-        "colornames": "0.0.2"
-      }
-    },
-    "largest-semantic-change": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/largest-semantic-change/-/largest-semantic-change-1.0.0.tgz",
-      "integrity": "sha1-JdxTi9qqi73DAnax6/kC1Ho0vw4=",
-      "dev": true,
-      "requires": {
-        "check-more-types": "2.23.0",
-        "lazy-ass": "1.5.0"
-      },
-      "dependencies": {
-        "check-more-types": {
-          "version": "2.23.0",
-          "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.23.0.tgz",
-          "integrity": "sha1-YiYmTTCxCVqhwKW4dO291dLQpm8=",
-          "dev": true
-        },
-        "lazy-ass": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.5.0.tgz",
-          "integrity": "sha1-yhW+JDx8R1uFZc2/oPnC83TyoB0=",
-          "dev": true
-        }
-      }
     },
     "latest-version": {
       "version": "5.1.0",
@@ -27381,33 +21981,6 @@
         }
       }
     },
-    "licenses": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/licenses/-/licenses-0.0.20.tgz",
-      "integrity": "sha1-8YpXsmp46vKKhz4qN4oz6B9Z0TY=",
-      "dev": true,
-      "requires": {
-        "async": "0.6.x",
-        "debug": "0.8.x",
-        "fusing": "0.2.x",
-        "githulk": "0.0.x",
-        "npm-registry": "0.1.x"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.6.2.tgz",
-          "integrity": "sha1-Qf0DijgSwKi8GELs8IumPrA5K+8=",
-          "dev": true
-        },
-        "debug": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
-          "integrity": "sha1-IP9NJvXkIstoobrLu2EDmtjBwTA=",
-          "dev": true
-        }
-      }
-    },
     "limit-it": {
       "version": "3.2.8",
       "resolved": "https://registry.npmjs.org/limit-it/-/limit-it-3.2.8.tgz",
@@ -27453,12 +22026,6 @@
         "path-exists": "^3.0.0"
       }
     },
-    "lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-      "dev": true
-    },
     "lodash.capitalize": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
@@ -27487,12 +22054,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
-      "dev": true
-    },
-    "lodash.map": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
       "dev": true
     },
     "lodash.memoize": {
@@ -27590,12 +22151,6 @@
         "loglevel": "^1.4.1"
       }
     },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
-    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -27621,23 +22176,6 @@
         "yallist": "^2.1.2"
       }
     },
-    "make-dir": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-      "dev": true,
-      "requires": {
-        "pify": "^3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        }
-      }
-    },
     "make-plural": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
@@ -27653,39 +22191,6 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true,
           "optional": true
-        }
-      }
-    },
-    "mana": {
-      "version": "0.1.41",
-      "resolved": "https://registry.npmjs.org/mana/-/mana-0.1.41.tgz",
-      "integrity": "sha1-fLE/cyGGaGVCKWNcT8Wxfib5O30=",
-      "dev": true,
-      "requires": {
-        "assign": ">=0.1.7",
-        "back": "1.0.x",
-        "diagnostics": "1.0.x",
-        "eventemitter3": "1.2.x",
-        "fusing": "1.0.x",
-        "millisecond": "0.1.x",
-        "request": "2.x.x"
-      },
-      "dependencies": {
-        "emits": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/emits/-/emits-3.0.0.tgz",
-          "integrity": "sha1-MnUrupXhcHshlWI4Srm7ix/WL3A=",
-          "dev": true
-        },
-        "fusing": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fusing/-/fusing-1.0.0.tgz",
-          "integrity": "sha1-VQwV12r5Jld4qgUezkTUAAoJjUU=",
-          "dev": true,
-          "requires": {
-            "emits": "3.0.x",
-            "predefine": "0.1.x"
-          }
         }
       }
     },
@@ -27921,18 +22426,6 @@
         "braces": "^3.0.1",
         "picomatch": "^2.0.5"
       }
-    },
-    "millisecond": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/millisecond/-/millisecond-0.1.2.tgz",
-      "integrity": "sha1-bMWtOGJByrjniv+WT4cCjuyS2sU=",
-      "dev": true
-    },
-    "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true
     },
     "mime-db": {
       "version": "1.33.0",
@@ -28292,21 +22785,6 @@
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
     },
-    "moment": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.17.0.tgz",
-      "integrity": "sha1-pMKS4CqsXd77Kabu0k9Rk43Tt08=",
-      "dev": true
-    },
-    "moment-timezone": {
-      "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.14.tgz",
-      "integrity": "sha1-TrOP+VOLgBCLpGekWPPtQmjM/LE=",
-      "dev": true,
-      "requires": {
-        "moment": ">= 2.9.0"
-      }
-    },
     "months": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/months/-/months-1.2.0.tgz",
@@ -28317,12 +22795,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
-    },
-    "mute-stream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
       "dev": true
     },
     "natural-compare": {
@@ -28342,209 +22814,6 @@
       "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
       "integrity": "sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo=",
       "dev": true
-    },
-    "netrc": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz",
-      "integrity": "sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ=",
-      "dev": true
-    },
-    "new-public-commits": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/new-public-commits/-/new-public-commits-1.3.1.tgz",
-      "integrity": "sha1-TXdVuHPwuesl9piNb3OSK4HX8RU=",
-      "dev": true,
-      "requires": {
-        "check-more-types": "2.24.0",
-        "debug": "2.6.8",
-        "ggit": "2.0.2",
-        "lazy-ass": "1.6.0",
-        "pluralize": "6.0.0",
-        "simple-commit-message": "3.3.1"
-      },
-      "dependencies": {
-        "am-i-a-dependency": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/am-i-a-dependency/-/am-i-a-dependency-1.0.0.tgz",
-          "integrity": "sha1-fA4usSYEU1CFLibkT2eBs+04eRk=",
-          "dev": true
-        },
-        "bluebird": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
-          "dev": true
-        },
-        "chdir-promise": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/chdir-promise/-/chdir-promise-0.4.1.tgz",
-          "integrity": "sha1-GIi7M3GWmcn7chOMB1VlA8SRPoU=",
-          "dev": true,
-          "requires": {
-            "check-more-types": "2.24.0",
-            "debug": "2.6.8",
-            "lazy-ass": "1.6.0",
-            "q": "1.5.0",
-            "spots": "0.5.0"
-          },
-          "dependencies": {
-            "q": {
-              "version": "1.5.0",
-              "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
-              "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
-              "dev": true
-            }
-          }
-        },
-        "commander": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ggit": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/ggit/-/ggit-2.0.2.tgz",
-          "integrity": "sha1-XIY2Sajar9QCDZHST7jNjxCQnhk=",
-          "dev": true,
-          "requires": {
-            "always-error": "1.0.0",
-            "bluebird": "3.5.0",
-            "chdir-promise": "0.4.1",
-            "check-more-types": "2.24.0",
-            "cli-table": "0.3.1",
-            "colors": "1.1.2",
-            "commander": "2.11.0",
-            "d3-helpers": "0.3.0",
-            "debug": "2.6.8",
-            "find-up": "2.1.0",
-            "glob": "7.1.2",
-            "lazy-ass": "1.6.0",
-            "lodash": "4.17.4",
-            "moment": "2.18.1",
-            "optimist": "0.6.1",
-            "pluralize": "6.0.0",
-            "q": "2.0.3",
-            "quote": "0.4.0",
-            "ramda": "0.24.1",
-            "semver": "5.4.1"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
-        "moment": {
-          "version": "2.18.1",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-          "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
-          "dev": true
-        },
-        "pluralize": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-6.0.0.tgz",
-          "integrity": "sha1-2bUa+tl9PVEHXMHdupsTLKzMt7o=",
-          "dev": true
-        },
-        "ramda": {
-          "version": "0.24.1",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
-          "integrity": "sha1-w7d1UZfzW43DUCIoJixMkd22uFc=",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-          "dev": true
-        },
-        "simple-commit-message": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/simple-commit-message/-/simple-commit-message-3.3.1.tgz",
-          "integrity": "sha512-TGODO8KgYQqd/Y/Ik1cdwUXp3mxvrWPBeB87xRzDnoru6dLsgaJkLxu9Db7+kjkbhvEMnnKbPgJb4h4iq1aHZw==",
-          "dev": true,
-          "requires": {
-            "am-i-a-dependency": "1.0.0",
-            "check-more-types": "2.24.0",
-            "debug": "2.6.8",
-            "ggit": "1.23.1",
-            "hr": "0.1.3",
-            "inquirer": "0.12.0",
-            "inquirer-confirm": "0.2.2",
-            "largest-semantic-change": "1.0.0",
-            "lazy-ass": "1.6.0",
-            "semver": "5.4.1",
-            "word-wrap": "1.2.3"
-          },
-          "dependencies": {
-            "ggit": {
-              "version": "1.23.1",
-              "resolved": "https://registry.npmjs.org/ggit/-/ggit-1.23.1.tgz",
-              "integrity": "sha1-5RPC8iKmJJpG5NDfNUuGBLW67ts=",
-              "dev": true,
-              "requires": {
-                "always-error": "1.0.0",
-                "bluebird": "3.5.0",
-                "chdir-promise": "0.4.1",
-                "check-more-types": "2.24.0",
-                "cli-table": "0.3.1",
-                "colors": "1.1.2",
-                "commander": "2.11.0",
-                "d3-helpers": "0.3.0",
-                "debug": "2.6.8",
-                "find-up": "2.1.0",
-                "glob": "7.1.2",
-                "lazy-ass": "1.6.0",
-                "lodash": "3.10.1",
-                "moment": "2.18.1",
-                "optimist": "0.6.1",
-                "pluralize": "6.0.0",
-                "q": "2.0.3",
-                "quote": "0.4.0",
-                "ramda": "0.24.1",
-                "semver": "5.4.1"
-              }
-            },
-            "lodash": {
-              "version": "3.10.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-              "dev": true
-            }
-          }
-        },
-        "spots": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/spots/-/spots-0.5.0.tgz",
-          "integrity": "sha1-t6oPGsOJpabVfCHpjaHVODlAX+E=",
-          "dev": true
-        }
-      }
     },
     "nice-try": {
       "version": "1.0.5",
@@ -32147,207 +26416,12 @@
         }
       }
     },
-    "npm-registry": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/npm-registry/-/npm-registry-0.1.13.tgz",
-      "integrity": "sha1-nl2LL9/Bq1mQ1H99674jHXmp6CI=",
-      "dev": true,
-      "requires": {
-        "debug": "0.8.x",
-        "extract-github": "0.0.x",
-        "licenses": "0.0.x",
-        "mana": "0.1.x",
-        "semver": "2.2.x"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
-          "integrity": "sha1-IP9NJvXkIstoobrLu2EDmtjBwTA=",
-          "dev": true
-        },
-        "semver": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz",
-          "integrity": "sha1-eUEYKz/8xYC/8cF5QqzfeVHA0hM=",
-          "dev": true
-        }
-      }
-    },
-    "npm-registry-client": {
-      "version": "0.2.31",
-      "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-0.2.31.tgz",
-      "integrity": "sha1-JKI+JOQyRmd8tIX4ORgp6VNlY9Q=",
-      "dev": true,
-      "requires": {
-        "chownr": "0",
-        "couch-login": "~0.1.18",
-        "graceful-fs": "~2.0.0",
-        "mkdirp": "~0.3.3",
-        "npmlog": "",
-        "request": "2 >=2.25.0",
-        "retry": "0.6.0",
-        "rimraf": "~2",
-        "semver": "^2.2.1",
-        "slide": "~1.1.3"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
-          "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
-          "dev": true
-        },
-        "semver": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
-          "integrity": "sha1-uYSPJdbPNjMwc+ye+IVtQvEjPlI=",
-          "dev": true
-        }
-      }
-    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
         "path-key": "^2.0.0"
-      }
-    },
-    "npm-utils": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/npm-utils/-/npm-utils-1.12.0.tgz",
-      "integrity": "sha1-ZJxbFFZuMx98awSIV9LEaidnnNk=",
-      "dev": true,
-      "requires": {
-        "chdir-promise": "0.4.0",
-        "check-more-types": "2.23.0",
-        "cross-spawn": "5.0.1",
-        "debug": "2.3.3",
-        "del": "2.2.2",
-        "ggit": "1.13.4",
-        "lazy-ass": "1.5.0",
-        "q": "2.0.3",
-        "registry-url": "3.1.0",
-        "repo-url": "1.0.0",
-        "user-home": "2.0.0",
-        "verbal-expressions": "0.2.1"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.4.6",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz",
-          "integrity": "sha1-AdqNgh2HgT0ViWfnQ9X+bGLPjA8=",
-          "dev": true
-        },
-        "chdir-promise": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chdir-promise/-/chdir-promise-0.4.0.tgz",
-          "integrity": "sha1-RtxgLtGTGXRwFA8VJFmkOCz3mXQ=",
-          "dev": true,
-          "requires": {
-            "check-more-types": "2.23.0",
-            "debug": "^2.3.3",
-            "lazy-ass": "1.5.0",
-            "q": "1.1.2",
-            "spots": "0.4.0"
-          },
-          "dependencies": {
-            "q": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
-              "integrity": "sha1-Y1fikSBnAdmfGXq4TlforRlvKok=",
-              "dev": true
-            }
-          }
-        },
-        "check-more-types": {
-          "version": "2.23.0",
-          "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.23.0.tgz",
-          "integrity": "sha1-YiYmTTCxCVqhwKW4dO291dLQpm8=",
-          "dev": true
-        },
-        "cross-spawn": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.0.1.tgz",
-          "integrity": "sha1-o7uzAtsil8vqPATt82lB9GE6o5k=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "debug": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
-        },
-        "ggit": {
-          "version": "1.13.4",
-          "resolved": "https://registry.npmjs.org/ggit/-/ggit-1.13.4.tgz",
-          "integrity": "sha1-UC53EGkYUj+gK4iv1Pe7ef35bTg=",
-          "dev": true,
-          "requires": {
-            "bluebird": "3.4.6",
-            "chdir-promise": "0.4.0",
-            "check-more-types": "2.23.0",
-            "cli-table": "0.3.1",
-            "colors": "1.1.2",
-            "commander": "2.9.0",
-            "d3-helpers": "0.3.0",
-            "debug": "2.3.3",
-            "glob": "7.1.1",
-            "lazy-ass": "1.5.0",
-            "lodash": "3.10.1",
-            "moment": "2.17.0",
-            "optimist": "0.6.1",
-            "q": "2.0.3",
-            "quote": "0.4.0",
-            "ramda": "0.9.1"
-          }
-        },
-        "lazy-ass": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.5.0.tgz",
-          "integrity": "sha1-yhW+JDx8R1uFZc2/oPnC83TyoB0=",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-          "dev": true
-        },
-        "ramda": {
-          "version": "0.9.1",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.9.1.tgz",
-          "integrity": "sha1-zJFNw6gsYI0AMJAgN4fD9oJsHYc=",
-          "dev": true
-        }
-      }
-    },
-    "npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
@@ -32373,17 +26447,6 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
       "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "dev": true
-    },
-    "object-keys": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.2.0.tgz",
-      "integrity": "sha1-zd7AKZiwkb5CvxA1rjLknxy26mc=",
-      "dev": true,
-      "requires": {
-        "foreach": "~2.0.1",
-        "indexof": "~0.0.1",
-        "is": "~0.2.6"
-      }
     },
     "object.assign": {
       "version": "4.1.0",
@@ -32465,12 +26528,6 @@
       "requires": {
         "deffy": "^2.0.0"
       }
-    },
-    "onetime": {
-      "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-      "dev": true
     },
     "optimist": {
       "version": "0.6.1",
@@ -32703,12 +26760,6 @@
         }
       }
     },
-    "parse-github-repo-url": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.0.tgz",
-      "integrity": "sha1-KGxT4smWLgZBZJ7jrJUI/KTdlZw=",
-      "dev": true
-    },
     "parse-it": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/parse-it/-/parse-it-1.0.8.tgz",
@@ -32790,21 +26841,6 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "^2.0.0"
-      }
     },
     "pkg-conf": {
       "version": "3.1.0",
@@ -32963,418 +26999,10 @@
       "integrity": "sha1-zqz9q0q/NT16DyqqLB/Hs/lBO6M=",
       "dev": true
     },
-    "pre-git": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/pre-git/-/pre-git-3.17.1.tgz",
-      "integrity": "sha512-/UH/OXKadgcm+7AvK7yNw5jxhN14/NSZ7rq8RgtJvX/KUjGtYQYx7UEAKIZtMjYZDO53nFpDVDr7SQzpVV55lA==",
-      "dev": true,
-      "requires": {
-        "bluebird": "3.5.1",
-        "chalk": "2.3.2",
-        "check-more-types": "2.24.0",
-        "conventional-commit-message": "1.1.0",
-        "cz-conventional-changelog": "2.1.0",
-        "debug": "3.1.0",
-        "ggit": "2.4.2",
-        "inquirer": "3.3.0",
-        "lazy-ass": "1.6.0",
-        "require-relative": "0.8.7",
-        "shelljs": "0.8.1",
-        "simple-commit-message": "4.0.3",
-        "validate-commit-msg": "2.14.0",
-        "word-wrap": "1.2.3"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "3.1.0",
-          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "bluebird": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "2.3.2",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "cli-cursor": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "^2.0.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "figures": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "^1.0.5"
-          }
-        },
-        "inquirer": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^3.0.0",
-            "chalk": "^2.0.0",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^2.0.4",
-            "figures": "^2.0.0",
-            "lodash": "^4.3.0",
-            "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rx-lite": "^4.0.8",
-            "rx-lite-aggregates": "^4.0.8",
-            "string-width": "^2.1.0",
-            "strip-ansi": "^4.0.0",
-            "through": "^2.3.6"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "largest-semantic-change": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/largest-semantic-change/-/largest-semantic-change-1.1.0.tgz",
-          "integrity": "sha1-R/W+AAaqNENH0+d2lRoD1caS0v0=",
-          "dev": true,
-          "requires": {
-            "check-more-types": "2.23.0",
-            "lazy-ass": "1.5.0"
-          },
-          "dependencies": {
-            "check-more-types": {
-              "version": "2.23.0",
-              "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.23.0.tgz",
-              "integrity": "sha1-YiYmTTCxCVqhwKW4dO291dLQpm8=",
-              "dev": true
-            },
-            "lazy-ass": {
-              "version": "1.5.0",
-              "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.5.0.tgz",
-              "integrity": "sha1-yhW+JDx8R1uFZc2/oPnC83TyoB0=",
-              "dev": true
-            }
-          }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
-        "mute-stream": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-          "dev": true
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "restore-cursor": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-          "dev": true,
-          "requires": {
-            "onetime": "^2.0.0",
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "run-async": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-          "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-          "dev": true,
-          "requires": {
-            "is-promise": "^2.1.0"
-          }
-        },
-        "rx-lite": {
-          "version": "4.0.8",
-          "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-          "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-          "dev": true
-        },
-        "shelljs": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.1.tgz",
-          "integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.0.0",
-            "interpret": "^1.0.0",
-            "rechoir": "^0.6.2"
-          }
-        },
-        "simple-commit-message": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/simple-commit-message/-/simple-commit-message-4.0.3.tgz",
-          "integrity": "sha512-eC4PcOUQJLIQTSxFM2qzTetbK9excIlRVu4DMQ1HaVjdfLJ7U1QEyyiLgIAhlcf7cnLol9qev1PSTlcZmj9dxg==",
-          "dev": true,
-          "requires": {
-            "am-i-a-dependency": "1.1.2",
-            "check-more-types": "2.24.0",
-            "debug": "3.1.0",
-            "ggit": "2.4.2",
-            "hr": "0.1.3",
-            "inquirer": "0.12.0",
-            "inquirer-confirm": "0.2.2",
-            "largest-semantic-change": "1.1.0",
-            "lazy-ass": "1.6.0",
-            "semver": "5.5.0",
-            "word-wrap": "1.2.3"
-          },
-          "dependencies": {
-            "ansi-escapes": {
-              "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-              "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-              "dev": true
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
-            },
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-              "dev": true
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              }
-            },
-            "cli-cursor": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-              "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-              "dev": true,
-              "requires": {
-                "restore-cursor": "^1.0.1"
-              }
-            },
-            "figures": {
-              "version": "1.7.0",
-              "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-              "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-              "dev": true,
-              "requires": {
-                "escape-string-regexp": "^1.0.5",
-                "object-assign": "^4.1.0"
-              }
-            },
-            "inquirer": {
-              "version": "0.12.0",
-              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-              "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-              "dev": true,
-              "requires": {
-                "ansi-escapes": "^1.1.0",
-                "ansi-regex": "^2.0.0",
-                "chalk": "^1.0.0",
-                "cli-cursor": "^1.0.1",
-                "cli-width": "^2.0.0",
-                "figures": "^1.3.5",
-                "lodash": "^4.3.0",
-                "readline2": "^1.0.1",
-                "run-async": "^0.1.0",
-                "rx-lite": "^3.1.2",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.0",
-                "through": "^2.3.6"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-              "dev": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "onetime": {
-              "version": "1.1.0",
-              "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-              "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-              "dev": true
-            },
-            "restore-cursor": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-              "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-              "dev": true,
-              "requires": {
-                "exit-hook": "^1.0.0",
-                "onetime": "^1.0.0"
-              }
-            },
-            "run-async": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-              "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-              "dev": true,
-              "requires": {
-                "once": "^1.3.0"
-              }
-            },
-            "rx-lite": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-              "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
-              "dev": true
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-              "dev": true
-            }
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
-    "predefine": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/predefine/-/predefine-0.1.2.tgz",
-      "integrity": "sha1-KqkrRJa8H4VU5DpF92v75Q0z038=",
-      "dev": true,
-      "requires": {
-        "extendible": "0.1.x"
-      }
-    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
-    },
-    "prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
     },
     "prettier": {
@@ -34394,26 +28022,6 @@
         "once": "^1.3.0"
       }
     },
-    "readline2": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "dev": true,
-      "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "mute-stream": "0.0.5"
-      }
-    },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
-      "requires": {
-        "resolve": "^1.1.6"
-      }
-    },
     "redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -34469,34 +28077,6 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
-    },
-    "registry-auth-token": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
-      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
-      "dev": true,
-      "requires": {
-        "rc": "^1.1.6",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "registry-url": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-      "dev": true,
-      "requires": {
-        "rc": "^1.0.1"
-      }
-    },
-    "repo-url": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/repo-url/-/repo-url-1.0.0.tgz",
-      "integrity": "sha1-CIWXsSYH9VmLqkchNtxzj7TjBFI=",
-      "dev": true,
-      "requires": {
-        "silent-npm-registry-client": "0.0.0"
-      }
     },
     "request": {
       "version": "2.87.0",
@@ -34594,62 +28174,16 @@
         "lowercase-keys": "^1.0.0"
       }
     },
-    "restore-cursor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true,
-      "requires": {
-        "exit-hook": "^1.0.0",
-        "onetime": "^1.0.0"
-      }
-    },
-    "retry": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz",
-      "integrity": "sha1-HAEHEyeab9Ho3vKK8MP/GHHKpTc=",
-      "dev": true
-    },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
     },
-    "right-pad": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/right-pad/-/right-pad-1.0.1.tgz",
-      "integrity": "sha1-jKCMLLtbVedNr6lr9/0aJ9VoyNA=",
-      "dev": true
-    },
-    "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.5"
-      }
-    },
-    "run-async": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true,
-      "requires": {
-        "once": "^1.3.0"
-      }
-    },
     "run-parallel": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
       "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
-      "dev": true
-    },
-    "rx": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz",
-      "integrity": "sha1-Ia3H2A8CACr1Da6X/Z2/JIdV9WY=",
       "dev": true
     },
     "rx-lite": {
@@ -35075,21 +28609,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
-    "semver-diff": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-      "dev": true,
-      "requires": {
-        "semver": "^5.0.3"
-      }
-    },
-    "semver-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz",
-      "integrity": "sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk=",
-      "dev": true
-    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -35182,633 +28701,6 @@
           "requires": {
             "find-up": "^2.0.0",
             "load-json-file": "^4.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
-    "silent-npm-registry-client": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/silent-npm-registry-client/-/silent-npm-registry-client-0.0.0.tgz",
-      "integrity": "sha1-gFAVIt8MGswsIRJWUm8PG5jbsN8=",
-      "dev": true,
-      "requires": {
-        "npm-registry-client": "~0.2.26",
-        "xtend": "~2.0.6"
-      },
-      "dependencies": {
-        "xtend": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.0.6.tgz",
-          "integrity": "sha1-XqZXptukRwacLlnFihE4ywxebO4=",
-          "dev": true,
-          "requires": {
-            "is-object": "~0.1.2",
-            "object-keys": "~0.2.0"
-          }
-        }
-      }
-    },
-    "simple-changelog": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/simple-changelog/-/simple-changelog-1.1.3.tgz",
-      "integrity": "sha1-gMKZjo4RNussxIn/vC/cz7K3guE=",
-      "dev": true,
-      "requires": {
-        "check-more-types": "2.24.0",
-        "common-tags": "1.4.0",
-        "debug": "2.6.8",
-        "ggit": "2.0.2",
-        "lazy-ass": "1.6.0",
-        "new-public-commits": "1.3.1",
-        "ramda": "0.24.1",
-        "simple-commit-message": "3.3.1"
-      },
-      "dependencies": {
-        "am-i-a-dependency": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/am-i-a-dependency/-/am-i-a-dependency-1.0.0.tgz",
-          "integrity": "sha1-fA4usSYEU1CFLibkT2eBs+04eRk=",
-          "dev": true
-        },
-        "bluebird": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
-          "dev": true
-        },
-        "chdir-promise": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/chdir-promise/-/chdir-promise-0.4.1.tgz",
-          "integrity": "sha1-GIi7M3GWmcn7chOMB1VlA8SRPoU=",
-          "dev": true,
-          "requires": {
-            "check-more-types": "2.24.0",
-            "debug": "2.6.8",
-            "lazy-ass": "1.6.0",
-            "q": "1.5.0",
-            "spots": "0.5.0"
-          },
-          "dependencies": {
-            "q": {
-              "version": "1.5.0",
-              "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
-              "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
-              "dev": true
-            }
-          }
-        },
-        "commander": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ggit": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/ggit/-/ggit-2.0.2.tgz",
-          "integrity": "sha1-XIY2Sajar9QCDZHST7jNjxCQnhk=",
-          "dev": true,
-          "requires": {
-            "always-error": "1.0.0",
-            "bluebird": "3.5.0",
-            "chdir-promise": "0.4.1",
-            "check-more-types": "2.24.0",
-            "cli-table": "0.3.1",
-            "colors": "1.1.2",
-            "commander": "2.11.0",
-            "d3-helpers": "0.3.0",
-            "debug": "2.6.8",
-            "find-up": "2.1.0",
-            "glob": "7.1.2",
-            "lazy-ass": "1.6.0",
-            "lodash": "4.17.4",
-            "moment": "2.18.1",
-            "optimist": "0.6.1",
-            "pluralize": "6.0.0",
-            "q": "2.0.3",
-            "quote": "0.4.0",
-            "ramda": "0.24.1",
-            "semver": "5.4.1"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
-        "moment": {
-          "version": "2.18.1",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-          "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
-          "dev": true
-        },
-        "pluralize": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-6.0.0.tgz",
-          "integrity": "sha1-2bUa+tl9PVEHXMHdupsTLKzMt7o=",
-          "dev": true
-        },
-        "ramda": {
-          "version": "0.24.1",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
-          "integrity": "sha1-w7d1UZfzW43DUCIoJixMkd22uFc=",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-          "dev": true
-        },
-        "simple-commit-message": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/simple-commit-message/-/simple-commit-message-3.3.1.tgz",
-          "integrity": "sha512-TGODO8KgYQqd/Y/Ik1cdwUXp3mxvrWPBeB87xRzDnoru6dLsgaJkLxu9Db7+kjkbhvEMnnKbPgJb4h4iq1aHZw==",
-          "dev": true,
-          "requires": {
-            "am-i-a-dependency": "1.0.0",
-            "check-more-types": "2.24.0",
-            "debug": "2.6.8",
-            "ggit": "1.23.1",
-            "hr": "0.1.3",
-            "inquirer": "0.12.0",
-            "inquirer-confirm": "0.2.2",
-            "largest-semantic-change": "1.0.0",
-            "lazy-ass": "1.6.0",
-            "semver": "5.4.1",
-            "word-wrap": "1.2.3"
-          },
-          "dependencies": {
-            "ggit": {
-              "version": "1.23.1",
-              "resolved": "https://registry.npmjs.org/ggit/-/ggit-1.23.1.tgz",
-              "integrity": "sha1-5RPC8iKmJJpG5NDfNUuGBLW67ts=",
-              "dev": true,
-              "requires": {
-                "always-error": "1.0.0",
-                "bluebird": "3.5.0",
-                "chdir-promise": "0.4.1",
-                "check-more-types": "2.24.0",
-                "cli-table": "0.3.1",
-                "colors": "1.1.2",
-                "commander": "2.11.0",
-                "d3-helpers": "0.3.0",
-                "debug": "2.6.8",
-                "find-up": "2.1.0",
-                "glob": "7.1.2",
-                "lazy-ass": "1.6.0",
-                "lodash": "3.10.1",
-                "moment": "2.18.1",
-                "optimist": "0.6.1",
-                "pluralize": "6.0.0",
-                "q": "2.0.3",
-                "quote": "0.4.0",
-                "ramda": "0.24.1",
-                "semver": "5.4.1"
-              }
-            },
-            "lodash": {
-              "version": "3.10.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-              "dev": true
-            }
-          }
-        },
-        "spots": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/spots/-/spots-0.5.0.tgz",
-          "integrity": "sha1-t6oPGsOJpabVfCHpjaHVODlAX+E=",
-          "dev": true
-        }
-      }
-    },
-    "simple-commit-message": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/simple-commit-message/-/simple-commit-message-4.1.3.tgz",
-      "integrity": "sha512-6L9cZeHWfHkPgjetER7D65SnWqb9S8txZ9K9xDvxQ+5uCPWhruN24wq0iZXZq0JDDdtPtW2oEV8Wia6P6nOtYg==",
-      "dev": true,
-      "requires": {
-        "check-more-types": "2.24.0",
-        "debug": "4.3.2",
-        "ggit": "2.4.12",
-        "hr": "0.1.3",
-        "inquirer": "6.5.2",
-        "inquirer-confirm": "2.0.7",
-        "largest-semantic-change": "1.1.0",
-        "lazy-ass": "1.6.0",
-        "semver": "5.7.1",
-        "word-wrap": "1.2.3"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "bluebird": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "chardet": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-          "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-          "dev": true
-        },
-        "cli-cursor": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "^2.0.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "colors": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
-          "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ==",
-          "dev": true
-        },
-        "commander": {
-          "version": "2.17.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-          "dev": true
-        },
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "external-editor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-          "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-          "dev": true,
-          "requires": {
-            "chardet": "^0.7.0",
-            "iconv-lite": "^0.4.24",
-            "tmp": "^0.0.33"
-          }
-        },
-        "figures": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "^1.0.5"
-          }
-        },
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "ggit": {
-          "version": "2.4.12",
-          "resolved": "https://registry.npmjs.org/ggit/-/ggit-2.4.12.tgz",
-          "integrity": "sha512-29DxkCEmqhXNk+JrV8GNQ+IY8OaJ1J2jC+B/vPvOk7CWs/2K8uX2DQeMlnFy7S+NeJrTNcLWfPJDdi6IflDt/A==",
-          "dev": true,
-          "requires": {
-            "always-error": "1.0.0",
-            "bluebird": "3.5.1",
-            "chdir-promise": "0.6.2",
-            "check-more-types": "2.24.0",
-            "cli-table": "0.3.1",
-            "colors": "1.3.2",
-            "commander": "2.17.1",
-            "d3-helpers": "0.3.0",
-            "debug": "3.2.6",
-            "find-up": "3.0.0",
-            "glob": "7.1.3",
-            "lazy-ass": "1.6.0",
-            "lodash": "4.17.15",
-            "moment": "2.23.0",
-            "moment-timezone": "0.5.23",
-            "optimist": "0.6.1",
-            "pluralize": "7.0.0",
-            "q": "2.0.3",
-            "quote": "0.4.0",
-            "ramda": "0.26.1",
-            "semver": "5.6.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.2.6",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-              "dev": true,
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            },
-            "semver": {
-              "version": "5.6.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-              "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
-              "dev": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "inquirer": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
-          "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^3.2.0",
-            "chalk": "^2.4.2",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^3.0.3",
-            "figures": "^2.0.0",
-            "lodash": "^4.17.12",
-            "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rxjs": "^6.4.0",
-            "string-width": "^2.1.0",
-            "strip-ansi": "^5.1.0",
-            "through": "^2.3.6"
-          }
-        },
-        "inquirer-confirm": {
-          "version": "2.0.7",
-          "resolved": "https://registry.npmjs.org/inquirer-confirm/-/inquirer-confirm-2.0.7.tgz",
-          "integrity": "sha512-H617sAqikrmgHpykbotLqnXK4lsXIJRMbnBATZ1JeoNPGJD1KyPG4UpWme35BZsMjWOkDcEqH+DdWYqYSCgA3g==",
-          "dev": true,
-          "requires": {
-            "inquirer": "6.5.2"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "largest-semantic-change": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/largest-semantic-change/-/largest-semantic-change-1.1.0.tgz",
-          "integrity": "sha1-R/W+AAaqNENH0+d2lRoD1caS0v0=",
-          "dev": true,
-          "requires": {
-            "check-more-types": "2.23.0",
-            "lazy-ass": "1.5.0"
-          },
-          "dependencies": {
-            "check-more-types": {
-              "version": "2.23.0",
-              "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.23.0.tgz",
-              "integrity": "sha1-YiYmTTCxCVqhwKW4dO291dLQpm8=",
-              "dev": true
-            },
-            "lazy-ass": {
-              "version": "1.5.0",
-              "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.5.0.tgz",
-              "integrity": "sha1-yhW+JDx8R1uFZc2/oPnC83TyoB0=",
-              "dev": true
-            }
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
-        },
-        "moment": {
-          "version": "2.23.0",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.23.0.tgz",
-          "integrity": "sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA==",
-          "dev": true
-        },
-        "moment-timezone": {
-          "version": "0.5.23",
-          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.23.tgz",
-          "integrity": "sha512-WHFH85DkCfiNMDX5D3X7hpNH3/PUhjTGcD0U1SgfBGZxJ3qUmJh5FdvaFjcClxOvB3rzdfj4oRffbI38jEnC1w==",
-          "dev": true,
-          "requires": {
-            "moment": ">= 2.9.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "mute-stream": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-          "dev": true
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true
-        },
-        "restore-cursor": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-          "dev": true,
-          "requires": {
-            "onetime": "^2.0.0",
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "run-async": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-          "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
-          "dev": true
-        },
-        "rxjs": {
-          "version": "6.6.7",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.0"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-              "dev": true
-            }
           }
         },
         "supports-color": {
@@ -36124,12 +29016,6 @@
         }
       }
     },
-    "spots": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/spots/-/spots-0.4.0.tgz",
-      "integrity": "sha1-Ae7F78FDZp2dOiDj7si4y9mELfY=",
-      "dev": true
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -36211,12 +29097,6 @@
         "duplexer2": "~0.1.0",
         "readable-stream": "^2.0.2"
       }
-    },
-    "stream-consume": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
-      "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg==",
-      "dev": true
     },
     "string_decoder": {
       "version": "1.1.1",
@@ -36636,42 +29516,10 @@
         }
       }
     },
-    "term-size": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-      "dev": true,
-      "requires": {
-        "execa": "^0.7.0"
-      },
-      "dependencies": {
-        "execa": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        }
-      }
-    },
     "text-extensions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
       "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
-      "dev": true
-    },
-    "text-hex": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz",
-      "integrity": "sha1-V4+8haapJjbkLdF7QdAhjM6esrM=",
       "dev": true
     },
     "text-table": {
@@ -36736,39 +29584,6 @@
       "dev": true,
       "requires": {
         "is-number": "^7.0.0"
-      }
-    },
-    "top-dependents": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/top-dependents/-/top-dependents-1.0.0.tgz",
-      "integrity": "sha1-+PdgEnymvQFlSs9xYObWAEzHH9A=",
-      "dev": true,
-      "requires": {
-        "check-more-types": "2.2.0",
-        "lazy-ass": "1.1.0",
-        "lodash": "3.10.1",
-        "npm-registry": "0.1.13",
-        "q": "1.4.1"
-      },
-      "dependencies": {
-        "check-more-types": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.2.0.tgz",
-          "integrity": "sha1-9eKvg0XQquYXxONEbmX6NTx/Rrs=",
-          "dev": true
-        },
-        "lazy-ass": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.1.0.tgz",
-          "integrity": "sha1-Wlkb1Twu4FLMUXIn9kwnmIIdf0k=",
-          "dev": true
-        },
-        "q": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-          "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
-          "dev": true
-        }
       }
     },
     "tough-cookie": {
@@ -36939,25 +29754,10 @@
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
-    "unique-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-      "dev": true,
-      "requires": {
-        "crypto-random-string": "^1.0.0"
-      }
-    },
     "universal-user-agent": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
       "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
-      "dev": true
-    },
-    "universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
     "update-notifier": {
@@ -37103,24 +29903,6 @@
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true
     },
-    "url-parse-lax": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-      "dev": true,
-      "requires": {
-        "prepend-http": "^1.0.1"
-      }
-    },
-    "user-home": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "^1.0.0"
-      }
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -37138,18 +29920,6 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
       "integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
       "dev": true
-    },
-    "validate-commit-msg": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/validate-commit-msg/-/validate-commit-msg-2.14.0.tgz",
-      "integrity": "sha1-5Tg2kQEsuycNzAvCpO/+vhSJDqw=",
-      "dev": true,
-      "requires": {
-        "conventional-commit-types": "^2.0.0",
-        "find-parent-dir": "^0.3.0",
-        "findup": "0.1.5",
-        "semver-regex": "1.0.0"
-      }
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -37170,12 +29940,6 @@
         "chalk": "^1.1.1",
         "object-assign": "^4.0.1"
       }
-    },
-    "verbal-expressions": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/verbal-expressions/-/verbal-expressions-0.2.1.tgz",
-      "integrity": "sha1-KLhF92Ddn5HWvDUdLgu0j6lcba8=",
-      "dev": true
     },
     "verror": {
       "version": "1.10.0",
@@ -37329,12 +30093,6 @@
           }
         }
       }
-    },
-    "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
     },
     "wordwrap": {
       "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -4,25 +4,6 @@
   "version": "0.0.0-development",
   "author": "Cypress <hello@cypress.io> (http://www.cypress.io/)",
   "bugs": "https://github.com/cypress-io/commit-info/issues",
-  "config": {
-    "pre-git": {
-      "commit-msg": "simple",
-      "pre-commit": [
-        "npm prune",
-        "npm run deps",
-        "npm test",
-        "git add src/*.js",
-        "npm run ban"
-      ],
-      "pre-push": [
-        "npm run license",
-        "npm run ban -- --all",
-        "npm run size"
-      ],
-      "post-commit": [],
-      "post-merge": []
-    }
-  },
   "engines": {
     "node": ">=6"
   },
@@ -61,29 +42,17 @@
     "unit": "mocha src/*-spec.js",
     "semantic-release": "semantic-release pre && npm publish --access public && semantic-release post"
   },
-  "release": {
-    "analyzeCommits": "simple-commit-message",
-    "generateNotes": "github-post-release",
-    "verifyRelease": {
-      "path": "dont-crack",
-      "test-against": []
-    }
-  },
   "devDependencies": {
     "ban-sensitive-files": "1.10.0",
     "chdir-promise": "0.6.2",
     "dependency-check": "4.1.0",
     "deps-ok": "1.4.1",
-    "dont-crack": "1.2.1",
     "git-issues": "1.3.1",
-    "github-post-release": "1.13.1",
     "license-checker": "25.0.1",
     "mocha": "6.2.1",
     "mocked-env": "1.3.1",
-    "pre-git": "3.17.1",
     "prettier-standard": "8.0.1",
     "semantic-release": "17.2.3",
-    "simple-commit-message": "4.1.3",
     "snap-shot-it": "7.9.3",
     "standard": "13.1.0",
     "stub-spawn-once": "2.3.0"


### PR DESCRIPTION
## Situation

### pre-git

The npm module [pre-git@3.17.1](https://github.com/bahmutov/pre-git/releases/tag/v3.17.1), configured in the repo, was released on Mar 13, 2018. This was 7 years ago and is the latest release of the module. The module is effectively unmaintained.

- `pre-git` contains multiple unfixable vulnerabilities:
  > 16 vulnerabilities (5 moderate, 7 high, 4 critical)
- The `postinstall` hook of `pre-git` adds a `semantic-release` configuration option, changing the default, if `simple-commit-message` has been uninstalled
  ```json
    "release": {
    "analyzeCommits": "simple-commit-message"
  },
  ```

### github-post-release

The npm module [github-post-release@1.13.1](https://github.com/bahmutov/github-post-release/releases/tag/v1.13.1), configured in the repo, was released on Aug 11, 2017. This was 8 years ago and is the latest release of the module. The module is effectively unmaintained.

- `github-post-release` contains multiple unfixable vulnerabilities:
  > 19 vulnerabilities (3 moderate, 10 high, 6 critical)

### dont-crack

The npm module [dont-crack@1.2.1](https://github.com/bahmutov/dont-crack/releases/tag/v1.2.1), configured in the repo, was released on Jun 7, 2017. This was 8 years ago and is the latest release of the module. The module is effectively unmaintained.

- `dont-crack` contains multiple unfixable vulnerabilities:
  > 36 vulnerabilities (3 low, 12 moderate, 15 high, 6 critical)

### simple-commit-message

[simple-commit-message](https://github.com/bahmutov/simple-commit-message) is in the `dependencies` section of [pre-git](https://github.com/bahmutov/pre-git) and of [github-post-release](https://github.com/bahmutov/github-post-release)therefore these need to be considered together:

The npm module [simple-commit-message@4.1.3](https://github.com/bahmutov/simple-commit-message/releases/tag/v4.1.3) configured in the repo, was released on Jul 4, 2021 and is the latest release. It is effectively unmaintained and has the following issues:

- Uses non-standard commit message types (see https://github.com/bahmutov/simple-commit-message/blob/master/README.md#valid-commit-messages) `major:` and `minor:`. Does not allow the use of `docs:`, `testing:`, etc. used in other Cypress repos.
- Contains multiple unfixable vulnerabilities:
  > 10 vulnerabilities (1 low, 2 moderate, 4 high, 3 critical)

## Assessment

[simple-commit-message](https://github.com/bahmutov/simple-commit-message), [pre-git](https://github.com/bahmutov/pre-git), [github-post-release](https://github.com/bahmutov/github-post-release) and [dont-crack](https://github.com/bahmutov/dont-crack) are linting components, intended to apply rules and increase the quality of the packaged module.

Their unmaintained and vulnerable status however means that they can no longer be used. It may be possible to replace their function using supported modules, however given the number of other issues in this repo, this enhancement would need to be deferred to a later stage.

The modules are used in the configuration of `semantic-release`. See also https://github.com/cypress-io/commit-info/issues/165 for separate releated configuration issues.

Since these modules are all interrelated, they need to be removed together.

## Change

In [package.json](https://github.com/cypress-io/commit-info/blob/master/package.json), remove:

- npm `devDependencies` modules:
  - [dont-crack](https://github.com/bahmutov/dont-crack)
  - [github-post-release](https://github.com/bahmutov/github-post-release)
  - [pre-git](https://github.com/bahmutov/pre-git)
  - [simple-commit-message](https://github.com/bahmutov/simple-commit-message)
- `config` key (`.github/hooks`)
- `release` key (`semantic-release` configuration)

## Verify

On Ubuntu `24.04.3` LTS, Node.js `22.18.0` LTS

execute the following and confirm no fatal errors are reported:

```shell
npm ci
npm test
npx semantic-release --dry-run
```

## Follow-up

Locally, it may be necessary to remove hooks from `.git/hooks` manually.
