### PR TITLE
fix(deps): update debug to 4.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "bluebird": "3.7.2",
         "check-more-types": "2.24.0",
-        "debug": "4.3.4",
+        "debug": "4.4.1",
         "execa": "1.0.0",
         "lazy-ass": "1.6.0",
         "ramda": "0.26.1"
@@ -2131,11 +2131,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -2147,9 +2148,10 @@
       }
     },
     "node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/decamelize": {
       "version": "4.0.0",
@@ -4675,24 +4677,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/mocha/node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/mocha/node_modules/escape-string-regexp": {
@@ -9088,6 +9072,31 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/snap-shot-it/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/snap-shot-it/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/snap-shot-it/node_modules/ramda": {
       "version": "0.28.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "bluebird": "3.7.2",
     "check-more-types": "2.24.0",
-    "debug": "4.3.4",
+    "debug": "4.4.1",
     "execa": "1.0.0",
     "lazy-ass": "1.6.0",
     "ramda": "0.26.1"


### PR DESCRIPTION
## Situation

[debug@4.3.4](https://github.com/debug-js/debug/releases/tag/4.3.4) is pinned to this fixed version in  `dependencies`. Compare this to [cypress@15.1.0](https://www.npmjs.com/package/cypress?activeTab=code) which is configured to use the semver range `"debug": "^4.3.4"` and thus ships with [debug@4.4.1](https://github.com/debug-js/debug/releases/tag/4.4.1)

## Change

Update

| From                                                                | To (`latest`)                                                       |
| ------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [debug@4.3.4](https://github.com/debug-js/debug/releases/tag/4.3.4) | [debug@4.4.1](https://github.com/debug-js/debug/releases/tag/4.4.1) |

## Verification

Ubuntu `24.04.3` LTS, Noded.js `22.19.0` LTS

```shell
git clean -xfd
npm ci
npm test
```

Confirm that tests are successful.

```shell
DEBUG=commit-info npm test
```

Confirm that debug logs are output.