### PR TITLE
ci: enable semantic-release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,7 @@ jobs:
         # only release from the master branch in parent repository, not in a fork
         if: (github.ref == 'refs/heads/master') &&
           (github.repository == 'cypress-io/commit-info')
-        # TODO: remove --dry-run after testing and when a real release is needed
-        run: npx semantic-release --dry-run
+        run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Situation

- For a considerable period of time since PR https://github.com/cypress-io/commit-info/pull/115 in Apr 2021, `semantic-release` in this repo was misconfigured and in a non-working state.

- PR https://github.com/cypress-io/commit-info/pull/167, in Sep 2025, reconfigured `semantic-release`, setting it temporarily into `dry-run` mode.

- Logs of the [actions/workflows/main.yml](https://github.com/cypress-io/commit-info/actions?query=branch%3Amaster) workflow show that `semantic-release` is working correctly and that there are the following dependency updates from the year 2023 queued for release:

  ```markdown
  ## 2.2.1 (https://github.com/cypress-io/commit-info/compare/v2.2.0...v2.2.1) (2025-09-04)

  ### Bug Fixes

      * **deps:** update debug to 4.3.4 🌟 ([e563983](https://github.com/cypress-io/commit-info/commit/e5639832cae219a7150587f987a4fefe5464c2da))
      * **deps:** update dependency bluebird to version 3.7.2 🌟 ([#150](https://github.com/cypress-io/commit-info/issues/150)) ([5b96920](https://github.com/cypress-io/commit-info/commit/5b969201e7e7404f022be67315b0089d898906e9))
  ```

## Change

Remove the `--dry-run` option (and TODO comment) from the `npx semantic-release --dry-run` command in the [.github/workflows/main.yml](https://github.com/cypress-io/commit-info/blob/master/.github/workflows/main.yml) workflow.