### PR TITLE
chore: remove eslint-env configuration comments

### DIFF
--- a/src/commit-info-spec.js
+++ b/src/commit-info-spec.js
@@ -1,6 +1,5 @@
 'use strict'
 
-/* eslint-env mocha */
 const { commitInfo } = require('.')
 const { stubSpawnShellOnce } = require('stub-spawn-once')
 const snapshot = require('snap-shot-it')

--- a/src/git-api-spec.js
+++ b/src/git-api-spec.js
@@ -8,7 +8,6 @@ const Promise = require('bluebird')
 const snapshot = require('snap-shot-it')
 const { join } = require('path')
 
-/* eslint-env mocha */
 describe('git-api', () => {
   const { gitCommands } = require('./git-api')
 

--- a/src/utils-spec.js
+++ b/src/utils-spec.js
@@ -4,7 +4,6 @@ const la = require('lazy-ass')
 const is = require('check-more-types')
 const { mergeWith, or } = require('ramda')
 
-/* eslint-env mocha */
 describe('utils', () => {
   describe('getFields', () => {
     const { getFields } = require('./utils')


### PR DESCRIPTION
## Situation

Several JavaScript source files in the [src](https://github.com/cypress-io/commit-info/tree/master/src) directory include the ESLint configuration comment:

> /* eslint-env mocha */

This is no longer used in ESLint flat configurations, and will cause an error in ESLint `10.x` and a warning in ESLint `>=9.39.2`.

See Configuration Migration Guide [`eslint-env` Configuration Comments](https://eslint.org/docs/latest/use/configure/migration-guide#eslint-env-configuration-comments) which says:

> ... when migrating from eslintrc to flat config, `eslint-env` configuration comments should be removed from all files.

This repo is already using an ESLint `9.x` flat configuration and the mocha globals are provided by using `mochaPlugin.configs.recommended`.

## Change

Remove the unused `eslint-env` configuration comment from source files in the [src](https://github.com/cypress-io/commit-info/tree/master/src) directory.

## Verification

```shell
npm ci
npx eslint
```

Confirm no errors reported.
